### PR TITLE
Add per-entity PLC availability addresses

### DIFF
--- a/custom_components/s7plc/binary_sensor.py
+++ b/custom_components/s7plc/binary_sensor.py
@@ -18,6 +18,8 @@ from .const import (
     CONF_DEVICE_CLASS,
     CONF_INVERT_STATE,
     CONF_SCAN_INTERVAL,
+    CONF_AVAILABILITY_ADDRESS,
+    CONF_AVAILABILITY_INVERT,
 )
 from .entity import S7BaseEntity
 from .helpers import default_entity_name, get_coordinator_and_device_info
@@ -49,6 +51,17 @@ async def async_setup_entry(
         device_class = item.get(CONF_DEVICE_CLASS)
         invert_state = item.get(CONF_INVERT_STATE, False)
         scan_interval = item.get(CONF_SCAN_INTERVAL)
+        availability_address = item.get(CONF_AVAILABILITY_ADDRESS)
+        availability_invert = item.get(CONF_AVAILABILITY_INVERT, False)
+        
+        availability_topic = None
+        if availability_address:
+            availability_topic = f"availability:{availability_address.upper()}"
+            await coord.add_item(
+                availability_topic,
+                availability_address,
+                scan_interval,
+            )
         await coord.add_item(topic, address, scan_interval)
 
         entities.append(
@@ -62,6 +75,9 @@ async def async_setup_entry(
                 device_class,
                 invert_state,
                 area,
+                availability_topic=availability_topic,
+                availability_address=availability_address,
+                availability_invert=availability_invert,
             )
         )
 
@@ -85,6 +101,9 @@ class S7BinarySensor(S7BaseEntity, BinarySensorEntity):
         device_class: str | None,
         invert_state: bool = False,
         suggested_area_id: str | None = None,
+        availability_topic: str | None = None,
+        availability_address: str | None = None,
+        availability_invert: bool = False,
     ):
         super().__init__(
             coordinator,
@@ -94,6 +113,9 @@ class S7BinarySensor(S7BaseEntity, BinarySensorEntity):
             topic=topic,
             address=address,
             suggested_area_id=suggested_area_id,
+            availability_topic=availability_topic,
+            availability_address=availability_address,
+            availability_invert=availability_invert,
         )
         self._invert_state = invert_state
         if device_class:

--- a/custom_components/s7plc/config_flow.py
+++ b/custom_components/s7plc/config_flow.py
@@ -39,6 +39,8 @@ except (ImportError, AttributeError):
 from .const import (
     CONF_ADDRESS,
     CONF_AREA,
+    CONF_AVAILABILITY_ADDRESS,
+    CONF_AVAILABILITY_INVERT,
     CONF_BACKOFF_INITIAL,
     CONF_BACKOFF_MAX,
     CONF_BINARY_SENSORS,
@@ -291,6 +293,10 @@ def _add_schema_sensor(flow) -> vol.Schema:
             vol.Optional(CONF_REAL_PRECISION): real_precision_selector,
             vol.Optional(CONF_SCAN_INTERVAL): scan_interval_selector,
             vol.Optional(CONF_AREA): flow._get_area_selector(),
+            vol.Optional(CONF_AVAILABILITY_ADDRESS): selector.TextSelector(),
+            vol.Optional(
+                CONF_AVAILABILITY_INVERT, default=False
+            ): selector.BooleanSelector(),
             vol.Optional("add_another", default=False): selector.BooleanSelector(),
         }
     )
@@ -307,6 +313,10 @@ def _add_schema_binary_sensor(flow) -> vol.Schema:
             ),
             vol.Optional(CONF_INVERT_STATE, default=False): selector.BooleanSelector(),
             vol.Optional(CONF_SCAN_INTERVAL): scan_interval_selector,
+            vol.Optional(CONF_AVAILABILITY_ADDRESS): selector.TextSelector(),
+            vol.Optional(
+                CONF_AVAILABILITY_INVERT, default=False
+            ): selector.BooleanSelector(),
             vol.Optional("add_another", default=False): selector.BooleanSelector(),
         }
     )
@@ -541,10 +551,17 @@ def _edit_schema_sensor(flow, item: dict[str, Any]) -> vol.Schema:
         (CONF_STATE_CLASS, state_class_selector),
         (CONF_REAL_PRECISION, real_precision_selector),
         (CONF_SCAN_INTERVAL, scan_interval_selector),
+        (CONF_AVAILABILITY_ADDRESS, selector.TextSelector()),
         (CONF_AREA, flow._get_area_selector()),
     ]:
         k, v = flow._optional_field(key, item, sel)
         d[k] = v
+    d[
+        vol.Optional(
+            CONF_AVAILABILITY_INVERT,
+            default=bool(item.get(CONF_AVAILABILITY_INVERT, False)),
+        )
+    ] = selector.BooleanSelector()
     return vol.Schema(d)
 
 
@@ -566,10 +583,17 @@ def _edit_schema_binary_sensor(flow, item: dict[str, Any]) -> vol.Schema:
     )
     for key, sel in [
         (CONF_SCAN_INTERVAL, scan_interval_selector),
+        (CONF_AVAILABILITY_ADDRESS, selector.TextSelector()),
         (CONF_AREA, flow._get_area_selector()),
     ]:
         k, v = flow._optional_field(key, item, sel)
         d[k] = v
+    d[
+        vol.Optional(
+            CONF_AVAILABILITY_INVERT,
+            default=bool(item.get(CONF_AVAILABILITY_INVERT, False)),
+        )
+    ] = selector.BooleanSelector()
     return vol.Schema(d)
 
 
@@ -2276,6 +2300,18 @@ class S7PLCOptionsFlow(config_entries.OptionsFlow):
         self._apply_real_precision(item, user_input.get(CONF_REAL_PRECISION))
         self._apply_scan_interval(item, user_input.get(CONF_SCAN_INTERVAL))
 
+        availability_address = user_input.get(CONF_AVAILABILITY_ADDRESS)
+        if availability_address:
+            availability_address, availability_errors = self._validate_address_field(
+                availability_address
+            )
+            if availability_errors:
+                return None, availability_errors
+            item[CONF_AVAILABILITY_ADDRESS] = availability_address
+            item[CONF_AVAILABILITY_INVERT] = bool(
+                user_input.get(CONF_AVAILABILITY_INVERT, False)
+            )
+
         return item, errors
 
     def _build_binary_sensor_item(
@@ -2305,6 +2341,18 @@ class S7PLCOptionsFlow(config_entries.OptionsFlow):
 
         # Apply specific transformations
         self._apply_scan_interval(item, user_input.get(CONF_SCAN_INTERVAL))
+
+        availability_address = user_input.get(CONF_AVAILABILITY_ADDRESS)
+        if availability_address:
+            availability_address, availability_errors = self._validate_address_field(
+                availability_address
+            )
+            if availability_errors:
+                return None, availability_errors
+            item[CONF_AVAILABILITY_ADDRESS] = availability_address
+            item[CONF_AVAILABILITY_INVERT] = bool(
+                user_input.get(CONF_AVAILABILITY_INVERT, False)
+            )
 
         return item, {}
 

--- a/custom_components/s7plc/const.py
+++ b/custom_components/s7plc/const.py
@@ -138,3 +138,5 @@ DEFAULT_BACKOFF_MAX = 2.0  # seconds
 DEFAULT_OPTIMIZE_READ = True  # enabled by default for better performance
 DEFAULT_ENABLE_WRITE_BATCHING = True  # enabled by default for better performance
 DEFAULT_ENABLE_METRICS = False  # disabled by default to avoid overhead
+CONF_AVAILABILITY_ADDRESS = "availability_address"
+CONF_AVAILABILITY_INVERT = "availability_invert"

--- a/custom_components/s7plc/entity.py
+++ b/custom_components/s7plc/entity.py
@@ -32,6 +32,9 @@ class S7BaseEntity(CoordinatorEntity):
         topic: str | None = None,
         address: str | None = None,
         suggested_area_id: str | None = None,
+        availability_topic: str | None = None,
+        availability_address: str | None = None,
+        availability_invert: bool = False,
     ) -> None:
         """Initialize S7 base entity.
 
@@ -43,6 +46,9 @@ class S7BaseEntity(CoordinatorEntity):
             topic: Optional topic name for data lookup
             address: Optional PLC address string
             suggested_area_id: Optional area ID suggestion for the entity
+            availability_topic: Optional topic for availability status
+            availability_address: Optional PLC address for availability
+            availability_invert: Whether to invert availability logic
         """
         super().__init__(coordinator)
         if name is not None:
@@ -51,6 +57,9 @@ class S7BaseEntity(CoordinatorEntity):
         self._attr_device_info = device_info
         self._topic = topic
         self._address = address
+        self._availability_topic = availability_topic
+        self._availability_address = availability_address
+        self._availability_invert = availability_invert
         if suggested_area_id:
             self._attr_suggested_area_id = suggested_area_id
 
@@ -63,30 +72,100 @@ class S7BaseEntity(CoordinatorEntity):
         if not self.coordinator.is_connected():
             raise HomeAssistantError("PLC not connected: cannot execute command.")
 
+    @staticmethod
+    def _availability_value_to_bool(value: object) -> bool:
+        """Convert a PLC availability value to bool safely.
+
+        pyS7/HA values may arrive as native bools, numbers, or strings.
+        Never use bool(value) directly here: bool(\"False\") is True.
+        """
+        if value is None:
+            return False
+
+        if isinstance(value, bool):
+            return value
+
+        if isinstance(value, (int, float)):
+            return value != 0
+
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "on", "yes", "y"}:
+                return True
+            if normalized in {
+                "0",
+                "false",
+                "off",
+                "no",
+                "n",
+                "",
+                "none",
+                "unknown",
+                "unavailable",
+            }:
+                return False
+            return False
+
+        return bool(value)
+
     @property
     def available(self) -> bool:
+        """Return whether the entity is available."""
         if not self.coordinator.is_connected():
             return False
-        if self._topic is None:
-            return True
+
         data = self.coordinator.data or {}
-        return (self._topic in data) and (data[self._topic] is not None)
+
+        topic = getattr(self, "_topic", None)
+        if topic is not None:
+            if topic not in data or data[topic] is None:
+                return False
+
+        availability_topic = getattr(self, "_availability_topic", None)
+        availability_invert = getattr(self, "_availability_invert", False)
+
+        if availability_topic:
+            available = self._availability_value_to_bool(data.get(availability_topic))
+
+            if availability_invert:
+                available = not available
+
+            if not available:
+                return False
+
+        return True
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity state attributes including S7-specific info."""
         attrs: dict[str, Any] = {}
+
         if self._address:
             attrs[self._address_attr_name] = self._address.upper()
+
         if self._topic:
             interval = self.coordinator.get_scan_interval(self._topic)
             attrs["scan_interval"] = f"{interval} s"
+
             precision = self.coordinator.get_real_precision(self._topic)
             if precision is not None:
                 attrs["real_precision"] = precision
-            invert_state = getattr(self, "_invert_state", None)
-            if invert_state is not None:
-                attrs["invert_state"] = invert_state
+
+        invert_state = getattr(self, "_invert_state", None)
+        if invert_state is not None:
+            attrs["invert_state"] = invert_state
+
+        availability_address = getattr(self, "_availability_address", None)
+        availability_topic = getattr(self, "_availability_topic", None)
+
+        if availability_address:
+            attrs["s7_availability_address"] = availability_address.upper()
+            attrs["availability_invert"] = getattr(self, "_availability_invert", False)
+            attrs["s7_availability_topic"] = availability_topic
+
+            data = self.coordinator.data or {}
+            attrs["s7_availability_value"] = data.get(availability_topic)
+
         return attrs
 
 
@@ -109,6 +188,9 @@ class S7BoolSyncEntity(S7BaseEntity):
         pulse_command: bool = False,
         pulse_duration: float = 0.5,
         suggested_area_id: str | None = None,
+        availability_topic: str | None = None,
+        availability_address: str | None = None,
+        availability_invert: bool = False,
     ) -> None:
         """Initialize boolean sync entity.
 
@@ -124,6 +206,9 @@ class S7BoolSyncEntity(S7BaseEntity):
             pulse_command: Whether to send pulse instead of on/off commands
             pulse_duration: Duration of pulse in seconds
             suggested_area_id: Optional area ID suggestion for the entity
+            availability_topic: Optional topic for availability status
+            availability_address: Optional PLC address for availability
+            availability_invert: Whether to invert availability logic
         """
         super().__init__(
             coordinator,
@@ -133,6 +218,9 @@ class S7BoolSyncEntity(S7BaseEntity):
             topic=topic,
             address=state_address,
             suggested_area_id=suggested_area_id,
+            availability_topic=availability_topic,
+            availability_address=availability_address,
+            availability_invert=availability_invert,
         )
         self._command_address = command_address
         self._pulse_command = pulse_command

--- a/custom_components/s7plc/sensor.py
+++ b/custom_components/s7plc/sensor.py
@@ -35,6 +35,8 @@ from .const import (
     CONF_STATE_CLASS,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_MULTIPLIER,
+    CONF_AVAILABILITY_ADDRESS,
+    CONF_AVAILABILITY_INVERT,
 )
 from .entity import S7BaseEntity
 from .helpers import (
@@ -279,19 +281,25 @@ DEVICE_CLASS_UNITS: dict[SensorDeviceClass, str | None] = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities,
 ):
     coord, device_info, device_id = get_coordinator_and_device_info(entry)
 
     entities = []
+
     for item in entry.options.get(CONF_SENSORS, []):
         address = item.get(CONF_ADDRESS)
         if not address:
             continue
+
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
+
         topic = f"sensor:{address}"
         unique_id = f"{device_id}:{topic}"
+
         device_class = item.get(CONF_DEVICE_CLASS)
         value_multiplier = item.get(CONF_VALUE_MULTIPLIER)
         unit_of_measurement = item.get(CONF_UNIT_OF_MEASUREMENT)
@@ -302,7 +310,25 @@ async def async_setup_entry(
         scale_raw_max = item.get(CONF_SCALE_RAW_MAX)
         min_value = item.get(CONF_MIN_VALUE)
         max_value = item.get(CONF_MAX_VALUE)
+
+        # Optional per-entity availability address.
+        # Example:
+        #   address: DB100,R4
+        #   availability_address: DB100,X0.0
+        availability_address = item.get(CONF_AVAILABILITY_ADDRESS)
+        availability_invert = item.get(CONF_AVAILABILITY_INVERT, False)
+
+        availability_topic = None
+        if availability_address:
+            availability_topic = f"availability:{availability_address.upper()}"
+            await coord.add_item(
+                availability_topic,
+                availability_address,
+                scan_interval,
+            )
+
         await coord.add_item(topic, address, scan_interval, real_precision)
+
         entities.append(
             S7Sensor(
                 coord,
@@ -320,6 +346,9 @@ async def async_setup_entry(
                 scale_raw_max=scale_raw_max,
                 min_value=min_value,
                 max_value=max_value,
+                availability_topic=availability_topic,
+                availability_address=availability_address,
+                availability_invert=availability_invert,
             )
         )
 
@@ -340,10 +369,12 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
-        await coord.async_request_refresh()
+
+    await coord.async_request_refresh()
 
     # Setup Entity Syncs
     sync_entities = []
+
     for item in entry.options.get(CONF_ENTITY_SYNC, []):
         address = item.get(CONF_ADDRESS)
         source_entity = item.get(CONF_SOURCE_ENTITY)
@@ -376,7 +407,6 @@ async def async_setup_entry(
     if sync_entities:
         async_add_entities(sync_entities)
 
-
 class S7Sensor(S7BaseEntity, SensorEntity):
 
     _address_attr_name = "s7_state_address"
@@ -398,6 +428,9 @@ class S7Sensor(S7BaseEntity, SensorEntity):
         scale_raw_max: float | None = None,
         min_value: float | None = None,
         max_value: float | None = None,
+        availability_topic: str | None = None,
+        availability_address: str | None = None,
+        availability_invert: bool = False,
     ):
         super().__init__(
             coordinator,
@@ -407,6 +440,9 @@ class S7Sensor(S7BaseEntity, SensorEntity):
             topic=topic,
             address=address,
             suggested_area_id=suggested_area_id,
+            availability_topic=availability_topic,
+            availability_address=availability_address,
+            availability_invert=availability_invert,
         )
 
         # Parse value_multiplier with defensive validation


### PR DESCRIPTION
## Summary

Add optional per-entity PLC availability addresses for sensors and binary sensors.

Each configured entity can use a separate PLC value to determine whether it should be available in Home Assistant. The result can also be inverted for signals where zero means healthy.

## Changes

- add `availability_address` and `availability_invert` configuration keys
- expose both options in add and edit flows for sensors and binary sensors
- validate and store the optional availability address
- register the availability address with the coordinator
- pass availability metadata to sensor and binary sensor entities
- evaluate bool, numeric, and common string values safely
- expose availability diagnostics as entity attributes

## Validation

- based on current upstream `main`
- Python syntax compilation passed for all modified files
- full automated test suite left to GitHub Actions
