### PR TITLE
Fix area-reload test's mock for the permanent-uid model

### DIFF
--- a/custom_components/s7plc/__init__.py
+++ b/custom_components/s7plc/__init__.py
@@ -298,9 +298,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
-    # Update areas in entity registry before reloading
-    await _async_update_entity_areas(hass, entry)
     await hass.config_entries.async_reload(entry.entry_id)
+
+    # Apply configured areas after reload, when newly added entities
+    # are available in the entity registry.
+    await _async_update_entity_areas(hass, entry)
 
 
 async def _async_update_entity_areas(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/s7plc/__init__.py
+++ b/custom_components/s7plc/__init__.py
@@ -43,7 +43,12 @@ from .const import (
     PLATFORMS,
 )
 from .coordinator import S7Coordinator
-from .helpers import RuntimeEntryData, build_entity_area_map, build_expected_unique_ids
+from .helpers import (
+    RuntimeEntryData,
+    build_entity_area_map,
+    build_expected_unique_ids,
+    ensure_item_uids,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,6 +102,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         local_tsap = None
         remote_tsap = None
         device_id = slugify(f"s7plc-{host}-{rack}-{slot}")
+
+    # Assign a permanent identity to every config item that doesn't have one
+    # yet, so unique_id no longer depends on any editable address field.
+    # Items that already correspond to a registered entity keep the exact
+    # same unique_id (see ensure_item_uids docstring); only brand-new items
+    # get a fresh one. Must run before platforms are set up.
+    if ensure_item_uids(device_id, entry.options):
+        hass.config_entries.async_update_entry(entry, options=entry.options)
 
     coordinator = S7Coordinator(
         hass,

--- a/custom_components/s7plc/binary_sensor.py
+++ b/custom_components/s7plc/binary_sensor.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_DEVICE_CLASS,
     CONF_INVERT_STATE,
     CONF_SCAN_INTERVAL,
+    CONF_UID,
 )
 from .entity import S7BaseEntity
 from .helpers import default_entity_name, get_coordinator_and_device_info
@@ -45,7 +46,7 @@ async def async_setup_entry(
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
         topic = f"binary_sensor:{address}"
-        unique_id = f"{device_id}:{topic}"
+        unique_id = f"{device_id}:{item[CONF_UID]}"
         device_class = item.get(CONF_DEVICE_CLASS)
         invert_state = item.get(CONF_INVERT_STATE, False)
         scan_interval = item.get(CONF_SCAN_INTERVAL)

--- a/custom_components/s7plc/binary_sensor.py
+++ b/custom_components/s7plc/binary_sensor.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
         topic = f"binary_sensor:{address}"
-        unique_id = f"{device_id}:{item[CONF_UID]}"
+        unique_id = item[CONF_UID]
         device_class = item.get(CONF_DEVICE_CLASS)
         invert_state = item.get(CONF_INVERT_STATE, False)
         scan_interval = item.get(CONF_SCAN_INTERVAL)

--- a/custom_components/s7plc/button.py
+++ b/custom_components/s7plc/button.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_AREA,
     CONF_BUTTON_PULSE,
     CONF_BUTTONS,
+    CONF_UID,
     DEFAULT_PULSE_DURATION,
 )
 from .entity import S7BaseEntity
@@ -37,7 +38,7 @@ async def async_setup_entry(
             continue
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
-        unique_id = f"{device_id}:button:{address}"
+        unique_id = f"{device_id}:{item[CONF_UID]}"
         button_pulse = item.get(CONF_BUTTON_PULSE, DEFAULT_PULSE_DURATION)
         entities.append(
             S7Button(coord, name, unique_id, device_info, address, button_pulse, area)

--- a/custom_components/s7plc/button.py
+++ b/custom_components/s7plc/button.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
     """Set up button entities from a config entry."""
-    coord, device_info, device_id = get_coordinator_and_device_info(entry)
+    coord, device_info, _ = get_coordinator_and_device_info(entry)
 
     entities = []
     for item in entry.options.get(CONF_BUTTONS, []):
@@ -38,7 +38,7 @@ async def async_setup_entry(
             continue
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
-        unique_id = f"{device_id}:{item[CONF_UID]}"
+        unique_id = item[CONF_UID]
         button_pulse = item.get(CONF_BUTTON_PULSE, DEFAULT_PULSE_DURATION)
         entities.append(
             S7Button(coord, name, unique_id, device_info, address, button_pulse, area)

--- a/custom_components/s7plc/climate.py
+++ b/custom_components/s7plc/climate.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_TARGET_TEMPERATURE_ADDRESS,
     CONF_TEMP_STEP,
+    CONF_UID,
     CONTROL_MODE_DIRECT,
     CONTROL_MODE_SETPOINT,
     DEFAULT_MAX_TEMP,
@@ -93,7 +94,7 @@ async def async_setup_entry(
             cooling_action = item.get(CONF_COOLING_ACTION_ADDRESS)
 
             topic = f"climate_direct:{current_temp_address}"
-            unique_id = f"{device_id}:{topic}"
+            unique_id = f"{device_id}:{item[CONF_UID]}"
 
             # Register current temperature for reading
             await coord.add_item(
@@ -140,7 +141,7 @@ async def async_setup_entry(
                 continue
 
             topic = f"climate_setpoint:{current_temp_address}"
-            unique_id = f"{device_id}:{topic}"
+            unique_id = f"{device_id}:{item[CONF_UID]}"
 
             # Register current and target temperature for reading
             await coord.add_item(

--- a/custom_components/s7plc/climate.py
+++ b/custom_components/s7plc/climate.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
     """Set up S7 climate entities."""
-    coord, device_info, device_id = get_coordinator_and_device_info(entry)
+    coord, device_info, _ = get_coordinator_and_device_info(entry)
 
     entities = []
     for item in entry.options.get(CONF_CLIMATES, []):
@@ -94,7 +94,7 @@ async def async_setup_entry(
             cooling_action = item.get(CONF_COOLING_ACTION_ADDRESS)
 
             topic = f"climate_direct:{current_temp_address}"
-            unique_id = f"{device_id}:{item[CONF_UID]}"
+            unique_id = item[CONF_UID]
 
             # Register current temperature for reading
             await coord.add_item(
@@ -141,7 +141,7 @@ async def async_setup_entry(
                 continue
 
             topic = f"climate_setpoint:{current_temp_address}"
-            unique_id = f"{device_id}:{item[CONF_UID]}"
+            unique_id = item[CONF_UID]
 
             # Register current and target temperature for reading
             await coord.add_item(

--- a/custom_components/s7plc/config_flow.py
+++ b/custom_components/s7plc/config_flow.py
@@ -101,6 +101,7 @@ from .const import (
     CONF_TARGET_TEMPERATURE_ADDRESS,
     CONF_TEMP_STEP,
     CONF_TEXTS,
+    CONF_UID,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_USE_STATE_TOPICS,
     CONF_VALUE_MULTIPLIER,
@@ -135,7 +136,12 @@ from .const import (
 )
 from .coordinator import S7Coordinator
 from .export import build_export_json, build_export_payload, register_export_download
-from .helpers import STATE_CLASS_VALUES, device_class_values, parse_pulse_duration
+from .helpers import (
+    STATE_CLASS_VALUES,
+    device_class_values,
+    generate_uid,
+    parse_pulse_duration,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -2075,6 +2081,11 @@ class S7PLCOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             new_item, errors = process_input(item, idx, user_input)
             if not errors and new_item is not None:
+                # Carry the item's permanent identity forward: the builder
+                # only sees user_input, never the old item, so it can't
+                # preserve this itself. Without this, editing any field
+                # would assign a fresh uid and orphan the existing entity.
+                new_item[CONF_UID] = item.get(CONF_UID) or generate_uid()
                 self._options[option_key][idx] = new_item
                 self._clear_edit_state()
                 return self.async_create_entry(title="", data=self._options)
@@ -2100,6 +2111,7 @@ class S7PLCOptionsFlow(config_entries.OptionsFlow):
                 )
 
             if item is not None:
+                item[CONF_UID] = generate_uid()
                 self._options[info.option_key].append(item)
 
             if user_input.get("add_another"):

--- a/custom_components/s7plc/const.py
+++ b/custom_components/s7plc/const.py
@@ -52,6 +52,10 @@ OPTION_KEYS = (
 
 CONF_ADDRESS = "address"
 CONF_AREA = "area"
+# Permanent per-item identity, assigned once at creation and never derived
+# from any editable field. unique_id is built from this, not from addresses,
+# so editing an item's address only changes its behavior, never its identity.
+CONF_UID = "uid"
 CONF_SOURCE_ENTITY = "source_entity"
 CONF_DEVICE_CLASS = "device_class"
 CONF_INVERT_STATE = "invert_state"

--- a/custom_components/s7plc/cover.py
+++ b/custom_components/s7plc/cover.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_STOP_COMMAND_ADDRESS,
     CONF_STOP_PULSE_DURATION,
+    CONF_UID,
     CONF_USE_STATE_TOPICS,
     DEFAULT_OPERATE_TIME,
     DEFAULT_PULSE_DURATION,
@@ -67,7 +68,7 @@ async def async_setup_entry(
             await coord.add_item(position_topic, position_state, scan_interval)
 
             name = item.get(CONF_NAME) or default_entity_name(position_state)
-            unique_id = f"{device_id}:{position_topic}"
+            unique_id = f"{device_id}:{item[CONF_UID]}"
             device_class = item.get(CONF_DEVICE_CLASS)
 
             entities.append(
@@ -117,8 +118,7 @@ async def async_setup_entry(
             await coord.add_item(closed_topic, closed_state, scan_interval)
 
         name = item.get(CONF_NAME) or default_entity_name(open_command)
-        unique_topic = opened_topic or closed_topic or f"cover:command:{open_command}"
-        unique_id = f"{device_id}:{unique_topic}"
+        unique_id = f"{device_id}:{item[CONF_UID]}"
         device_class = item.get(CONF_DEVICE_CLASS)
 
         raw_operate_time = item.get(CONF_OPERATE_TIME, DEFAULT_OPERATE_TIME)

--- a/custom_components/s7plc/cover.py
+++ b/custom_components/s7plc/cover.py
@@ -47,7 +47,7 @@ PARALLEL_UPDATES = 1
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
-    coord, device_info, device_id = get_coordinator_and_device_info(entry)
+    coord, device_info, _ = get_coordinator_and_device_info(entry)
 
     entities: list[S7Cover | S7PositionCover] = []
 
@@ -68,7 +68,7 @@ async def async_setup_entry(
             await coord.add_item(position_topic, position_state, scan_interval)
 
             name = item.get(CONF_NAME) or default_entity_name(position_state)
-            unique_id = f"{device_id}:{item[CONF_UID]}"
+            unique_id = item[CONF_UID]
             device_class = item.get(CONF_DEVICE_CLASS)
 
             entities.append(
@@ -118,7 +118,7 @@ async def async_setup_entry(
             await coord.add_item(closed_topic, closed_state, scan_interval)
 
         name = item.get(CONF_NAME) or default_entity_name(open_command)
-        unique_id = f"{device_id}:{item[CONF_UID]}"
+        unique_id = item[CONF_UID]
         device_class = item.get(CONF_DEVICE_CLASS)
 
         raw_operate_time = item.get(CONF_OPERATE_TIME, DEFAULT_OPERATE_TIME)

--- a/custom_components/s7plc/helpers.py
+++ b/custom_components/s7plc/helpers.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator, Mapping
+import uuid
+from collections.abc import Iterator, Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -34,25 +35,32 @@ from .const import (
     CONF_BUTTONS,
     CONF_CLIMATE_CONTROL_MODE,
     CONF_CLIMATES,
+    CONF_CLOSE_COMMAND_ADDRESS,
     CONF_CLOSING_STATE_ADDRESS,
+    CONF_COOLING_OUTPUT_ADDRESS,
     CONF_COVERS,
     CONF_CURRENT_TEMPERATURE_ADDRESS,
     CONF_ENABLE_METRICS,
     CONF_ENTITY_SYNC,
+    CONF_HEATING_OUTPUT_ADDRESS,
     CONF_LIGHTS,
     CONF_NUMBERS,
     CONF_OPEN_COMMAND_ADDRESS,
     CONF_OPENING_STATE_ADDRESS,
     CONF_POSITION_STATE_ADDRESS,
     CONF_SENSORS,
+    CONF_SOURCE_ENTITY,
     CONF_STATE_ADDRESS,
     CONF_SWITCHES,
+    CONF_TARGET_TEMPERATURE_ADDRESS,
     CONF_TEXTS,
+    CONF_UID,
     CONTROL_MODE_DIRECT,
     CONTROL_MODE_SETPOINT,
     DEFAULT_ENABLE_METRICS,
     DEFAULT_PULSE_DURATION,
     DOMAIN,
+    OPTION_KEYS,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checking only
@@ -258,13 +266,17 @@ def parse_pulse_duration(value: Any | None) -> float:
 # ---------------------------------------------------------------------------
 
 
-def _iter_entity_unique_ids(
+def _iter_legacy_unique_ids(
     device_id: str, options: Mapping[str, Any]
 ) -> Iterator[tuple[str, dict[str, Any]]]:
-    """Yield ``(unique_id, config_item)`` for every configured entity.
+    """Yield ``(unique_id, config_item)`` using the old, address-based formula.
 
-    This is the single source of truth for the mapping
-    *configuration item  →  entity unique_id*.
+    Frozen on purpose: this is no longer the live source of truth (see
+    :func:`_iter_entity_unique_ids` below), but :func:`ensure_item_uids`
+    needs it to know what unique_id an item *currently* has in the entity
+    registry, so it can carry that exact value forward as the item's
+    permanent ``uid`` instead of generating a new one and orphaning the
+    existing entity.
     """
 
     # Sensors — device_id:sensor:address
@@ -341,6 +353,103 @@ def _iter_entity_unique_ids(
         address = item.get(CONF_ADDRESS, "")
         if address:
             yield f"{device_id}:entity_sync:{address}", item
+
+
+def generate_uid() -> str:
+    """Return a short random identifier for a newly created config item."""
+    return uuid.uuid4().hex[:12]
+
+
+def _item_has_required_fields(option_key: str, item: Mapping[str, Any]) -> bool:
+    """Return whether *item* has enough configured to produce a real entity.
+
+    Mirrors the per-type conditions each platform's ``async_setup_entry``
+    already checks before creating an entity, so the "expected" set below
+    doesn't oversell items that won't actually be created.
+    """
+    if option_key in (
+        CONF_SENSORS,
+        CONF_BINARY_SENSORS,
+        CONF_BUTTONS,
+        CONF_NUMBERS,
+        CONF_TEXTS,
+    ):
+        return bool(item.get(CONF_ADDRESS))
+    if option_key == CONF_ENTITY_SYNC:
+        return bool(item.get(CONF_ADDRESS) and item.get(CONF_SOURCE_ENTITY))
+    if option_key == CONF_SWITCHES:
+        return bool(item.get(CONF_STATE_ADDRESS))
+    if option_key == CONF_LIGHTS:
+        return bool(item.get(CONF_STATE_ADDRESS) or item.get(CONF_ADDRESS))
+    if option_key == CONF_COVERS:
+        if item.get(CONF_POSITION_STATE_ADDRESS):
+            return True
+        return bool(
+            item.get(CONF_OPEN_COMMAND_ADDRESS) and item.get(CONF_CLOSE_COMMAND_ADDRESS)
+        )
+    if option_key == CONF_CLIMATES:
+        if not item.get(CONF_CURRENT_TEMPERATURE_ADDRESS):
+            return False
+        control_mode = item.get(CONF_CLIMATE_CONTROL_MODE, CONTROL_MODE_SETPOINT)
+        if control_mode == CONTROL_MODE_DIRECT:
+            return bool(
+                item.get(CONF_HEATING_OUTPUT_ADDRESS)
+                or item.get(CONF_COOLING_OUTPUT_ADDRESS)
+            )
+        return bool(item.get(CONF_TARGET_TEMPERATURE_ADDRESS))
+    return True
+
+
+def ensure_item_uids(device_id: str, options: MutableMapping[str, Any]) -> bool:
+    """Assign a permanent ``uid`` to every config item that doesn't have one.
+
+    For an item that already corresponds to a registered entity (matched via
+    the frozen, address-based :func:`_iter_legacy_unique_ids`), the *exact*
+    string it already resolves to is reused as its ``uid`` — so the entity's
+    unique_id/entity_id doesn't change at all, only becomes independent of
+    the address going forward. Items with no legacy match (e.g. missing a
+    required field, so they never produced an entity) get a fresh random uid.
+
+    Returns whether anything changed, so the caller knows whether to persist
+    *options* back onto the config entry.
+    """
+    prefix = f"{device_id}:"
+    legacy_by_item_id = {
+        id(item): legacy_id
+        for legacy_id, item in _iter_legacy_unique_ids(device_id, options)
+    }
+
+    changed = False
+    for option_key in OPTION_KEYS:
+        for item in options.get(option_key, []):
+            if CONF_UID in item:
+                continue
+            legacy_id = legacy_by_item_id.get(id(item))
+            if legacy_id and legacy_id.startswith(prefix):
+                item[CONF_UID] = legacy_id[len(prefix) :]
+            else:
+                item[CONF_UID] = generate_uid()
+            changed = True
+    return changed
+
+
+def _iter_entity_unique_ids(
+    device_id: str, options: Mapping[str, Any]
+) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Yield ``(unique_id, config_item)`` for every configured entity.
+
+    This is the single source of truth for the mapping
+    *configuration item → entity unique_id*, built from each item's
+    permanent :data:`CONF_UID` rather than any editable address field. Items
+    are expected to already have a ``uid`` (assigned by
+    :func:`ensure_item_uids` at setup time); one lacking it is skipped, not
+    an error, since it would mean setup hasn't run the backfill yet.
+    """
+    for option_key in OPTION_KEYS:
+        for item in options.get(option_key, []):
+            uid = item.get(CONF_UID)
+            if uid and _item_has_required_fields(option_key, item):
+                yield f"{device_id}:{uid}", item
 
 
 def build_expected_unique_ids(

--- a/custom_components/s7plc/helpers.py
+++ b/custom_components/s7plc/helpers.py
@@ -403,17 +403,19 @@ def _item_has_required_fields(option_key: str, item: Mapping[str, Any]) -> bool:
 def ensure_item_uids(device_id: str, options: MutableMapping[str, Any]) -> bool:
     """Assign a permanent ``uid`` to every config item that doesn't have one.
 
-    For an item that already corresponds to a registered entity (matched via
-    the frozen, address-based :func:`_iter_legacy_unique_ids`), the *exact*
-    string it already resolves to is reused as its ``uid`` — so the entity's
-    unique_id/entity_id doesn't change at all, only becomes independent of
-    the address going forward. Items with no legacy match (e.g. missing a
-    required field, so they never produced an entity) get a fresh random uid.
+    ``uid`` holds the item's *complete* unique_id, not a suffix combined with
+    ``device_id`` at read time — so identity survives connection-parameter
+    changes (host/rack/slot/TSAP), not just address edits. For an item that
+    already corresponds to a registered entity (matched via the frozen,
+    address-based :func:`_iter_legacy_unique_ids`), the *exact* string it
+    already resolves to is reused verbatim as its ``uid`` — so the entity's
+    unique_id/entity_id doesn't change at all. Items with no legacy match
+    (e.g. missing a required field, so they never produced an entity) get a
+    fresh random uid.
 
     Returns whether anything changed, so the caller knows whether to persist
     *options* back onto the config entry.
     """
-    prefix = f"{device_id}:"
     legacy_by_item_id = {
         id(item): legacy_id
         for legacy_id, item in _iter_legacy_unique_ids(device_id, options)
@@ -425,31 +427,29 @@ def ensure_item_uids(device_id: str, options: MutableMapping[str, Any]) -> bool:
             if CONF_UID in item:
                 continue
             legacy_id = legacy_by_item_id.get(id(item))
-            if legacy_id and legacy_id.startswith(prefix):
-                item[CONF_UID] = legacy_id[len(prefix) :]
-            else:
-                item[CONF_UID] = generate_uid()
+            item[CONF_UID] = legacy_id if legacy_id else generate_uid()
             changed = True
     return changed
 
 
 def _iter_entity_unique_ids(
-    device_id: str, options: Mapping[str, Any]
+    options: Mapping[str, Any],
 ) -> Iterator[tuple[str, dict[str, Any]]]:
     """Yield ``(unique_id, config_item)`` for every configured entity.
 
     This is the single source of truth for the mapping
-    *configuration item → entity unique_id*, built from each item's
-    permanent :data:`CONF_UID` rather than any editable address field. Items
-    are expected to already have a ``uid`` (assigned by
-    :func:`ensure_item_uids` at setup time); one lacking it is skipped, not
-    an error, since it would mean setup hasn't run the backfill yet.
+    *configuration item → entity unique_id*, built entirely from each item's
+    permanent :data:`CONF_UID` (no ``device_id`` involved, so identity is
+    independent of connection settings too). Items are expected to already
+    have a ``uid`` (assigned by :func:`ensure_item_uids` at setup time); one
+    lacking it is skipped, not an error, since it would mean setup hasn't run
+    the backfill yet.
     """
     for option_key in OPTION_KEYS:
         for item in options.get(option_key, []):
             uid = item.get(CONF_UID)
             if uid and _item_has_required_fields(option_key, item):
-                yield f"{device_id}:{uid}", item
+                yield uid, item
 
 
 def build_expected_unique_ids(
@@ -464,7 +464,7 @@ def build_expected_unique_ids(
     """
     from .sensor import METRICS_DEFINITIONS
 
-    ids = {uid for uid, _ in _iter_entity_unique_ids(device_id, options)}
+    ids = {uid for uid, _ in _iter_entity_unique_ids(options)}
     ids.add(f"{device_id}:connection")
     # enable_metrics lives in entry.data, not in entry.options
     source = data if data is not None else options
@@ -480,5 +480,5 @@ def build_entity_area_map(
     """Return a mapping ``unique_id → area_id`` for all configured entities."""
     return {
         uid: item.get(CONF_AREA)
-        for uid, item in _iter_entity_unique_ids(device_id, options)
+        for uid, item in _iter_entity_unique_ids(options)
     }

--- a/custom_components/s7plc/helpers.py
+++ b/custom_components/s7plc/helpers.py
@@ -356,8 +356,8 @@ def _iter_legacy_unique_ids(
 
 
 def generate_uid() -> str:
-    """Return a short random identifier for a newly created config item."""
-    return uuid.uuid4().hex[:12]
+    """Return a random identifier for a newly created config item."""
+    return uuid.uuid4().hex
 
 
 def _item_has_required_fields(option_key: str, item: Mapping[str, Any]) -> bool:

--- a/custom_components/s7plc/light.py
+++ b/custom_components/s7plc/light.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_STATE_ADDRESS,
     CONF_SYNC_STATE,
+    CONF_UID,
     DEFAULT_PULSE_DURATION,
 )
 from .entity import S7BoolSyncEntity
@@ -58,7 +59,7 @@ async def async_setup_entry(
         scan_interval = item.get(CONF_SCAN_INTERVAL)
 
         topic = f"light:{state_address}"
-        unique_id = f"{device_id}:{topic}"
+        unique_id = f"{device_id}:{item[CONF_UID]}"
 
         # Always register the boolean on/off topic
         await coord.add_item(topic, state_address, scan_interval)

--- a/custom_components/s7plc/light.py
+++ b/custom_components/s7plc/light.py
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
-    coord, device_info, device_id = get_coordinator_and_device_info(entry)
+    coord, device_info, _ = get_coordinator_and_device_info(entry)
 
     entities = []
     for item in entry.options.get(CONF_LIGHTS, []):
@@ -59,7 +59,7 @@ async def async_setup_entry(
         scan_interval = item.get(CONF_SCAN_INTERVAL)
 
         topic = f"light:{state_address}"
-        unique_id = f"{device_id}:{item[CONF_UID]}"
+        unique_id = item[CONF_UID]
 
         # Always register the boolean on/off topic
         await coord.add_item(topic, state_address, scan_interval)

--- a/custom_components/s7plc/number.py
+++ b/custom_components/s7plc/number.py
@@ -46,7 +46,7 @@ PARALLEL_UPDATES = 1
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
-    coord, device_info, device_id = get_coordinator_and_device_info(entry)
+    coord, device_info, _ = get_coordinator_and_device_info(entry)
 
     entities: list[S7Number] = []
     for item in entry.options.get(CONF_NUMBERS, []):
@@ -56,7 +56,7 @@ async def async_setup_entry(
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
         topic = f"number:{address}"
-        unique_id = f"{device_id}:{item[CONF_UID]}"
+        unique_id = item[CONF_UID]
         command_address = item.get(CONF_COMMAND_ADDRESS) or address
         min_value = item.get(CONF_MIN_VALUE)
         max_value = item.get(CONF_MAX_VALUE)

--- a/custom_components/s7plc/number.py
+++ b/custom_components/s7plc/number.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_SCALE_RAW_MIN,
     CONF_SCAN_INTERVAL,
     CONF_STEP,
+    CONF_UID,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_MULTIPLIER,
 )
@@ -55,7 +56,7 @@ async def async_setup_entry(
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
         topic = f"number:{address}"
-        unique_id = f"{device_id}:{topic}"
+        unique_id = f"{device_id}:{item[CONF_UID]}"
         command_address = item.get(CONF_COMMAND_ADDRESS) or address
         min_value = item.get(CONF_MIN_VALUE)
         max_value = item.get(CONF_MAX_VALUE)

--- a/custom_components/s7plc/panel.py
+++ b/custom_components/s7plc/panel.py
@@ -8,7 +8,7 @@ from typing import Any
 import voluptuous as vol
 import yaml
 
-from .const import DOMAIN, OPTION_KEYS
+from .const import CONF_UID, DOMAIN, OPTION_KEYS
 
 PANEL_URL = "s7plc-config"
 PANEL_DATA = "_panel_registered"
@@ -49,18 +49,20 @@ _OPTION_DOMAINS = {
 
 
 def _entity_ids_payload(hass: Any, entry: Any) -> dict[str, list[str | None]]:
-    """Map every configured item to its Home Assistant entity_id (or None)."""
+    """Map every configured item to its Home Assistant entity_id (or None).
+
+    ``uid`` is already the complete unique_id (see helpers.CONF_UID), so no
+    device_id concatenation is needed here. Items without a uid yet (not
+    backfilled by ``ensure_item_uids`` because setup hasn't run) are simply
+    skipped by ``_iter_entity_unique_ids`` and resolve to ``None`` below.
+    """
     from homeassistant.helpers import entity_registry as er
 
     from .helpers import _iter_entity_unique_ids
 
-    device_id = getattr(getattr(entry, "runtime_data", None), "device_id", None)
-    if not device_id:
-        return {key: [None] * len(entry.options.get(key, [])) for key in OPTION_KEYS}
-
     registry = er.async_get(hass)
     uid_by_item = {
-        id(item): uid for uid, item in _iter_entity_unique_ids(device_id, entry.options)
+        id(item): uid for uid, item in _iter_entity_unique_ids(entry.options)
     }
     payload: dict[str, list[str | None]] = {}
     for key in OPTION_KEYS:
@@ -148,6 +150,8 @@ async def async_setup_panel(hass: Any) -> None:
     @websocket_api.require_admin
     @websocket_api.async_response
     async def ws_save_entity(hass, connection, msg):
+        from .helpers import generate_uid
+
         entry = hass.config_entries.async_get_entry(msg["entry_id"])
         if entry is None or entry.domain != DOMAIN:
             connection.send_error(
@@ -163,11 +167,18 @@ async def async_setup_panel(hass: Any) -> None:
             connection.send_error(msg["id"], "invalid_entity", str(err))
             return
         if index is None:
+            # New entity: assign a permanent uid now rather than relying on
+            # ensure_item_uids to backfill one at the next reload.
+            entity[CONF_UID] = generate_uid()
             items.append(entity)
         elif index < 0 or index >= len(items):
             connection.send_error(msg["id"], "invalid_index", "Entity no longer exists")
             return
         else:
+            # Preserve the existing item's uid as a backend guarantee, not
+            # an accident of the frontend echoing it back unchanged (the
+            # YAML editor lets a user delete that line from the payload).
+            entity[CONF_UID] = items[index].get(CONF_UID) or generate_uid()
             items[index] = entity
         options[msg["entity_type"]] = items
         hass.config_entries.async_update_entry(entry, options=options)

--- a/custom_components/s7plc/sensor.py
+++ b/custom_components/s7plc/sensor.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_SENSORS,
     CONF_SOURCE_ENTITY,
     CONF_STATE_CLASS,
+    CONF_UID,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_MULTIPLIER,
 )
@@ -291,7 +292,7 @@ async def async_setup_entry(
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
         topic = f"sensor:{address}"
-        unique_id = f"{device_id}:{topic}"
+        unique_id = f"{device_id}:{item[CONF_UID]}"
         device_class = item.get(CONF_DEVICE_CLASS)
         value_multiplier = item.get(CONF_VALUE_MULTIPLIER)
         unit_of_measurement = item.get(CONF_UNIT_OF_MEASUREMENT)
@@ -359,7 +360,7 @@ async def async_setup_entry(
 
         name = item.get(CONF_NAME) or default_entity_name(f"Entity Sync {address}")
         area = item.get(CONF_AREA)
-        unique_id = f"{device_id}:entity_sync:{address}"
+        unique_id = f"{device_id}:{item[CONF_UID]}"
 
         sync_entities.append(
             S7EntitySync(

--- a/custom_components/s7plc/sensor.py
+++ b/custom_components/s7plc/sensor.py
@@ -292,7 +292,7 @@ async def async_setup_entry(
         name = item.get(CONF_NAME) or default_entity_name(address)
         area = item.get(CONF_AREA)
         topic = f"sensor:{address}"
-        unique_id = f"{device_id}:{item[CONF_UID]}"
+        unique_id = item[CONF_UID]
         device_class = item.get(CONF_DEVICE_CLASS)
         value_multiplier = item.get(CONF_VALUE_MULTIPLIER)
         unit_of_measurement = item.get(CONF_UNIT_OF_MEASUREMENT)
@@ -360,7 +360,7 @@ async def async_setup_entry(
 
         name = item.get(CONF_NAME) or default_entity_name(f"Entity Sync {address}")
         area = item.get(CONF_AREA)
-        unique_id = f"{device_id}:{item[CONF_UID]}"
+        unique_id = item[CONF_UID]
 
         sync_entities.append(
             S7EntitySync(

--- a/custom_components/s7plc/switch.py
+++ b/custom_components/s7plc/switch.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_STATE_ADDRESS,
     CONF_SWITCHES,
     CONF_SYNC_STATE,
+    CONF_UID,
     DEFAULT_PULSE_DURATION,
 )
 from .entity import S7BoolSyncEntity
@@ -44,7 +45,7 @@ async def async_setup_entry(
         name = item.get(CONF_NAME) or default_entity_name(state_address)
         area = item.get(CONF_AREA)
         topic = f"switch:{state_address}"
-        unique_id = f"{device_id}:{topic}"
+        unique_id = f"{device_id}:{item[CONF_UID]}"
         scan_interval = item.get(CONF_SCAN_INTERVAL)
         await coord.add_item(topic, state_address, scan_interval)
         entities.append(

--- a/custom_components/s7plc/switch.py
+++ b/custom_components/s7plc/switch.py
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
-    coord, device_info, device_id = get_coordinator_and_device_info(entry)
+    coord, device_info, _ = get_coordinator_and_device_info(entry)
 
     entities = []
     for item in entry.options.get(CONF_SWITCHES, []):
@@ -45,7 +45,7 @@ async def async_setup_entry(
         name = item.get(CONF_NAME) or default_entity_name(state_address)
         area = item.get(CONF_AREA)
         topic = f"switch:{state_address}"
-        unique_id = f"{device_id}:{item[CONF_UID]}"
+        unique_id = item[CONF_UID]
         scan_interval = item.get(CONF_SCAN_INTERVAL)
         await coord.add_item(topic, state_address, scan_interval)
         entities.append(

--- a/custom_components/s7plc/text.py
+++ b/custom_components/s7plc/text.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_PATTERN,
     CONF_SCAN_INTERVAL,
     CONF_TEXTS,
+    CONF_UID,
 )
 from .entity import S7BaseEntity
 from .helpers import default_entity_name, get_coordinator_and_device_info
@@ -71,7 +72,7 @@ async def async_setup_entry(
         max_length = tag.length if tag.length is not None else 254
 
         topic = f"text:{address}"
-        unique_id = f"{device_id}:{topic}"
+        unique_id = f"{device_id}:{text_config[CONF_UID]}"
         await coordinator.add_item(topic, address, scan_interval, None)
 
         entities.append(

--- a/custom_components/s7plc/text.py
+++ b/custom_components/s7plc/text.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities,
 ):
     """Set up text entities from config entry."""
-    coordinator, device_info, device_id = get_coordinator_and_device_info(entry)
+    coordinator, device_info, _ = get_coordinator_and_device_info(entry)
 
     config = entry.options or entry.data
     texts = config.get(CONF_TEXTS, [])
@@ -72,7 +72,7 @@ async def async_setup_entry(
         max_length = tag.length if tag.length is not None else 254
 
         topic = f"text:{address}"
-        unique_id = f"{device_id}:{text_config[CONF_UID]}"
+        unique_id = text_config[CONF_UID]
         await coordinator.add_item(topic, address, scan_interval, None)
 
         entities.append(

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -19,6 +19,7 @@ from custom_components.s7plc.const import (
     CONF_BINARY_SENSORS,
     CONF_DEVICE_CLASS,
     CONF_SCAN_INTERVAL,
+    CONF_UID,
 )
 from conftest import DummyCoordinator
 
@@ -324,10 +325,12 @@ async def test_async_setup_entry_with_sensors(fake_hass, mock_coordinator, devic
                 CONF_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Sensor 1",
                 CONF_DEVICE_CLASS: "door",
+                CONF_UID: "uid-1",
             },
             {
                 CONF_ADDRESS: "db1,x0.1",
                 CONF_NAME: "Sensor 2",
+                CONF_UID: "uid-2",
             }
         ]
     }
@@ -360,7 +363,7 @@ async def test_async_setup_entry_skip_missing_address(fake_hass, mock_coordinato
     config_entry.options = {
         CONF_BINARY_SENSORS: [
             {CONF_NAME: "No Address Sensor"},
-            {CONF_ADDRESS: "db1,x0.0", CONF_NAME: "Valid Sensor"},
+            {CONF_ADDRESS: "db1,x0.0", CONF_NAME: "Valid Sensor", CONF_UID: "uid-1"},
         ]
     }
     
@@ -387,7 +390,7 @@ async def test_async_setup_entry_default_name(fake_hass, mock_coordinator, devic
     config_entry = MagicMock()
     config_entry.options = {
         CONF_BINARY_SENSORS: [
-            {CONF_ADDRESS: "db1,x0.0"}  # No name
+            {CONF_ADDRESS: "db1,x0.0", CONF_UID: "uid-1"}  # No name
         ]
     }
     
@@ -414,6 +417,7 @@ async def test_async_setup_entry_with_scan_interval(fake_hass, mock_coordinator,
                 CONF_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Sensor 1",
                 CONF_SCAN_INTERVAL: 5,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -441,6 +445,7 @@ async def test_async_setup_entry_with_invert_state(fake_hass, mock_coordinator, 
                 CONF_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Inverted Sensor",
                 "invert_state": True,
+                CONF_UID: "uid-1",
             }
         ]
     }

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -23,6 +23,7 @@ from custom_components.s7plc.const import (
     CONF_MIN_TEMP,
     CONF_TARGET_TEMPERATURE_ADDRESS,
     CONF_TEMP_STEP,
+    CONF_UID,
     CONTROL_MODE_DIRECT,
     CONTROL_MODE_SETPOINT,
 )
@@ -391,6 +392,7 @@ async def test_setup_entry_direct_control(fake_hass, mock_coordinator):
                 CONF_MIN_TEMP: 10.0,
                 CONF_MAX_TEMP: 30.0,
                 CONF_TEMP_STEP: 0.5,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -427,6 +429,7 @@ async def test_setup_entry_setpoint_control(fake_hass, mock_coordinator):
                 CONF_MIN_TEMP: 15.0,
                 CONF_MAX_TEMP: 28.0,
                 CONF_TEMP_STEP: 0.5,
+                CONF_UID: "uid-1",
             }
         ]
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -253,7 +253,53 @@ def test_edit_sensor_scan_interval_can_be_cleared():
     assert result["type"] == "create_entry"
     sensor = flow._options[const.CONF_SENSORS][0]
     assert const.CONF_SCAN_INTERVAL not in sensor
-    
+
+
+def test_add_sensor_assigns_uid():
+    """A newly added item gets a permanent uid, independent of its address."""
+    flow = make_options_flow(options={const.CONF_SENSORS: []})
+
+    result = run_flow(
+        flow.async_step_sensors({const.CONF_ADDRESS: "DB1,X0.0"})
+    )
+
+    assert result["type"] == "create_entry"
+    sensor = flow._options[const.CONF_SENSORS][0]
+    assert sensor[const.CONF_UID]
+
+
+def test_edit_sensor_preserves_uid_when_address_changes():
+    """Regression test: editing an item's address must not change its uid.
+
+    Before the stable-uid fix, unique_id was derived straight from the
+    address, so editing it orphaned the existing entity. Now the uid is
+    assigned once at creation and must survive address edits unchanged.
+    """
+    options = {
+        const.CONF_SENSORS: [
+            {const.CONF_ADDRESS: "DB1,X0.0", const.CONF_UID: "original-uid"}
+        ]
+    }
+
+    flow = make_options_flow(options=options)
+    flow._action = "edit"
+    flow._edit_target = ("s", 0)
+
+    result = run_flow(
+        flow.async_step_edit_sensor(
+            {
+                const.CONF_ADDRESS: "DB2,X1.0",  # address changed
+                CONF_NAME: "",
+                const.CONF_SCAN_INTERVAL: "",
+            }
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    sensor = flow._options[const.CONF_SENSORS][0]
+    assert sensor[const.CONF_ADDRESS] == "DB2,X1.0"
+    assert sensor[const.CONF_UID] == "original-uid"
+
 
 def test_add_sensor_with_value_multiplier():
     flow = make_options_flow(options={const.CONF_SENSORS: []})
@@ -537,6 +583,28 @@ def test_import_step_accepts_unique_addresses():
     assert len(flow._options[const.CONF_SENSORS]) == 2
     assert len(flow._options[const.CONF_SWITCHES]) == 1
     assert len(flow._options[const.CONF_BUTTONS]) == 1
+
+
+def test_import_step_preserves_existing_uid():
+    """A uid already present in the imported JSON (e.g. from this
+    integration's own export) must survive untouched, so re-importing a
+    backup doesn't orphan existing entities."""
+    flow = make_options_flow()
+
+    payload = {
+        const.CONF_SENSORS: [
+            {
+                const.CONF_ADDRESS: "DB1,X0.0",
+                CONF_NAME: "Sensor 1",
+                const.CONF_UID: "preserved-uid",
+            },
+        ],
+    }
+
+    result = run_flow(flow.async_step_import({"import_json": json.dumps(payload)}))
+
+    assert result["type"] == "create_entry"
+    assert flow._options[const.CONF_SENSORS][0][const.CONF_UID] == "preserved-uid"
 
 
 def test_import_step_allows_same_address_across_entity_types():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -383,7 +383,11 @@ def test_import_step_replaces_configuration():
 
     new_payload = {
         const.CONF_SENSORS: [
-            {const.CONF_ADDRESS: "DB10.DBW0", CONF_NAME: "New"}
+            {
+                const.CONF_ADDRESS: "DB10.DBW0",
+                CONF_NAME: "New",
+                const.CONF_AREA: "kitchen",
+            }
         ],
         const.CONF_LIGHTS: [
             {
@@ -401,7 +405,10 @@ def test_import_step_replaces_configuration():
     assert flow._options[const.CONF_SENSORS][0][const.CONF_ADDRESS] == "DB10.DBW0"
     assert flow._options[const.CONF_LIGHTS][0][const.CONF_COMMAND_ADDRESS] == "Q1.1"
     assert flow._options[const.CONF_BUTTONS] == []
-
+    assert (
+        flow._options[const.CONF_SENSORS][0][const.CONF_AREA]
+        == "kitchen"
+    )
 
 def test_import_step_handles_invalid_json():
     flow = make_options_flow()

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -16,6 +16,7 @@ from custom_components.s7plc.const import (
     CONF_OPEN_COMMAND_ADDRESS,
     CONF_OPENING_STATE_ADDRESS,
     CONF_OPERATE_TIME,
+    CONF_UID,
     CONF_USE_STATE_TOPICS,
     DEFAULT_OPERATE_TIME,
 )
@@ -444,6 +445,7 @@ async def test_async_setup_entry_with_covers(fake_hass, mock_coordinator, device
                 CONF_OPEN_COMMAND_ADDRESS: "db1,x0.0",
                 CONF_CLOSE_COMMAND_ADDRESS: "db1,x0.1",
                 CONF_NAME: "Cover 1",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -472,6 +474,7 @@ async def test_async_setup_entry_skip_missing_addresses(fake_hass, mock_coordina
             {
                 CONF_OPEN_COMMAND_ADDRESS: "db1,x0.2",
                 CONF_CLOSE_COMMAND_ADDRESS: "db1,x0.3",
+                CONF_UID: "uid-1",
             },  # Valid
         ]
     }
@@ -499,6 +502,7 @@ async def test_async_setup_entry_with_state_addresses(fake_hass, mock_coordinato
                 CONF_OPENING_STATE_ADDRESS: "db1,x1.0",
                 CONF_CLOSING_STATE_ADDRESS: "db1,x1.1",
                 CONF_NAME: "Cover with States",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -526,6 +530,7 @@ async def test_async_setup_entry_default_operate_time(fake_hass, mock_coordinato
             {
                 CONF_OPEN_COMMAND_ADDRESS: "db1,x0.0",
                 CONF_CLOSE_COMMAND_ADDRESS: "db1,x0.1",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -551,6 +556,7 @@ async def test_async_setup_entry_custom_operate_time(fake_hass, mock_coordinator
                 CONF_OPEN_COMMAND_ADDRESS: "db1,x0.0",
                 CONF_CLOSE_COMMAND_ADDRESS: "db1,x0.1",
                 CONF_OPERATE_TIME: 30,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -576,6 +582,7 @@ async def test_async_setup_entry_invalid_operate_time(fake_hass, mock_coordinato
                 CONF_OPEN_COMMAND_ADDRESS: "db1,x0.0",
                 CONF_CLOSE_COMMAND_ADDRESS: "db1,x0.1",
                 CONF_OPERATE_TIME: "invalid",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -601,6 +608,7 @@ async def test_async_setup_entry_negative_operate_time(fake_hass, mock_coordinat
                 CONF_OPEN_COMMAND_ADDRESS: "db1,x0.0",
                 CONF_CLOSE_COMMAND_ADDRESS: "db1,x0.1",
                 CONF_OPERATE_TIME: -5,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -626,6 +634,7 @@ async def test_async_setup_entry_use_state_topics(fake_hass, mock_coordinator, d
                 CONF_OPEN_COMMAND_ADDRESS: "db1,x0.0",
                 CONF_CLOSE_COMMAND_ADDRESS: "db1,x0.1",
                 CONF_USE_STATE_TOPICS: True,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -661,6 +670,7 @@ async def test_position_cover_setup(fake_hass, mock_coordinator, device_info):
                 CONF_POSITION_STATE_ADDRESS: "db1,b0",
                 CONF_POSITION_COMMAND_ADDRESS: "db1,b1",
                 CONF_NAME: "Test Position Cover",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -1227,6 +1237,7 @@ async def test_position_cover_setup_with_stop_address(fake_hass, mock_coordinato
                 CONF_STOP_COMMAND_ADDRESS: "db1,x1.0",
                 CONF_STOP_PULSE_DURATION: 2.0,
                 CONF_NAME: "Test Position Cover",
+                CONF_UID: "uid-1",
             }
         ]
     }

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -16,6 +16,7 @@ from custom_components.s7plc.const import (
     CONF_BUTTONS,
     CONF_BUTTON_PULSE,
     CONF_NUMBERS,
+    CONF_UID,
     DEFAULT_PULSE_DURATION,
 )
 
@@ -653,7 +654,7 @@ async def test_number_setup_entry_generates_name_from_address(mock_coordinator, 
     entry = dummy_entry(
         options={
             CONF_NUMBERS: [
-                {CONF_ADDRESS: "db1,w0"}  # no name -> default_entity_name()
+                {CONF_ADDRESS: "db1,w0", CONF_UID: "uid-1"}  # no name -> default_entity_name()
             ]
         }
     )
@@ -686,9 +687,9 @@ async def test_button_setup_entry_pulse_parsing(mock_coordinator, fake_hass, dum
     entry = dummy_entry(
         options={
             CONF_BUTTONS: [
-                {CONF_ADDRESS: "db1,x0.0", CONF_BUTTON_PULSE: 2.0},
-                {CONF_ADDRESS: "db1,x0.1", CONF_BUTTON_PULSE: 0.3},
-                {CONF_ADDRESS: "db1,x0.2"},  # missing -> default
+                {CONF_ADDRESS: "db1,x0.0", CONF_BUTTON_PULSE: 2.0, CONF_UID: "uid-1"},
+                {CONF_ADDRESS: "db1,x0.1", CONF_BUTTON_PULSE: 0.3, CONF_UID: "uid-2"},
+                {CONF_ADDRESS: "db1,x0.2", CONF_UID: "uid-3"},  # missing -> default
             ]
         }
     )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
 from custom_components.s7plc import export
+from custom_components.s7plc.const import CONF_ADDRESS, CONF_SENSORS, CONF_UID
+
+
+def test_build_export_payload_preserves_uid():
+    """The permanent uid must round-trip through export unchanged."""
+    options = {
+        CONF_SENSORS: [{CONF_ADDRESS: "DB1,REAL0", CONF_UID: "abc123"}],
+    }
+
+    payload = export.build_export_payload(options)
+
+    assert payload[CONF_SENSORS][0][CONF_UID] == "abc123"
 
 
 class _FakeHTTP:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock
 from custom_components.s7plc.helpers import (
     build_entity_area_map,
     build_expected_unique_ids,
+    ensure_item_uids,
+    generate_uid,
     get_coordinator_and_device_info,
     default_entity_name,
     parse_pulse_duration,
@@ -92,54 +94,73 @@ def test_get_coordinator_and_device_info_different_names():
 
 
 def test_build_expected_unique_ids_all_entity_types():
-    """Every entity type is represented plus the connection sensor."""
+    """Every entity type is represented plus the connection sensor.
+
+    unique_id is now derived from each item's permanent "uid" field, not
+    from its address — so every fixture item needs one.
+    """
     options = {
-        "sensors": [{"address": "DB1,REAL0"}],
-        "binary_sensors": [{"address": "DB1,X0.0"}],
-        "switches": [{"state_address": "DB1,X0.1"}],
+        "sensors": [{"address": "DB1,REAL0", "uid": "uid-sensor"}],
+        "binary_sensors": [{"address": "DB1,X0.0", "uid": "uid-binary"}],
+        "switches": [{"state_address": "DB1,X0.1", "uid": "uid-switch"}],
         "covers": [
-            {"position_state_address": "DB1,INT0"},
+            {"position_state_address": "DB1,INT0", "uid": "uid-cover-pos"},
             {
                 "open_command_address": "DB1,X1.0",
                 "close_command_address": "DB1,X1.1",
                 "opening_state_address": "DB1,X1.2",
+                "uid": "uid-cover-trad",
             },
         ],
-        "buttons": [{"address": "DB1,X2.0"}],
+        "buttons": [{"address": "DB1,X2.0", "uid": "uid-button"}],
         "lights": [
-            {"state_address": "DB1,X2.1"},
-            {"state_address": "DB1,B10", "brightness_scale": 255},
+            {"state_address": "DB1,X2.1", "uid": "uid-light-1"},
+            {
+                "state_address": "DB1,B10",
+                "brightness_scale": 255,
+                "uid": "uid-light-2",
+            },
         ],
-        "numbers": [{"address": "DB1,INT10"}],
-        "texts": [{"address": "DB1,STRING0"}],
+        "numbers": [{"address": "DB1,INT10", "uid": "uid-number"}],
+        "texts": [{"address": "DB1,STRING0", "uid": "uid-text"}],
         "climates": [
             {
                 "current_temperature_address": "DB1,REAL20",
                 "control_mode": "direct",
+                "heating_output_address": "DB1,X3.0",
+                "uid": "uid-climate-direct",
             },
             {
                 "current_temperature_address": "DB1,REAL30",
                 "control_mode": "setpoint",
+                "target_temperature_address": "DB1,REAL31",
+                "uid": "uid-climate-setpoint",
             },
         ],
-        "entity_sync": [{"address": "DB1,REAL100", "source_entity": "sensor.test"}],
+        "entity_sync": [
+            {
+                "address": "DB1,REAL100",
+                "source_entity": "sensor.test",
+                "uid": "uid-entity-sync",
+            }
+        ],
     }
 
     ids = build_expected_unique_ids("dev", options)
 
-    assert "dev:sensor:DB1,REAL0" in ids
-    assert "dev:binary_sensor:DB1,X0.0" in ids
-    assert "dev:switch:DB1,X0.1" in ids
-    assert "dev:cover:position:DB1,INT0" in ids
-    assert "dev:cover:opened:DB1,X1.2" in ids
-    assert "dev:button:DB1,X2.0" in ids
-    assert "dev:light:DB1,X2.1" in ids
-    assert "dev:light:DB1,B10" in ids
-    assert "dev:number:DB1,INT10" in ids
-    assert "dev:text:DB1,STRING0" in ids
-    assert "dev:climate_direct:DB1,REAL20" in ids
-    assert "dev:climate_setpoint:DB1,REAL30" in ids
-    assert "dev:entity_sync:DB1,REAL100" in ids
+    assert "dev:uid-sensor" in ids
+    assert "dev:uid-binary" in ids
+    assert "dev:uid-switch" in ids
+    assert "dev:uid-cover-pos" in ids
+    assert "dev:uid-cover-trad" in ids
+    assert "dev:uid-button" in ids
+    assert "dev:uid-light-1" in ids
+    assert "dev:uid-light-2" in ids
+    assert "dev:uid-number" in ids
+    assert "dev:uid-text" in ids
+    assert "dev:uid-climate-direct" in ids
+    assert "dev:uid-climate-setpoint" in ids
+    assert "dev:uid-entity-sync" in ids
     assert "dev:connection" in ids
 
 
@@ -163,24 +184,44 @@ def test_build_expected_unique_ids_empty_options_with_metrics():
 
 
 def test_build_expected_unique_ids_traditional_cover_variants():
-    """Traditional covers pick the right unique id based on available addresses."""
-    # opened_state takes priority
+    """Traditional covers (open+close command required) get their uid-based id."""
+    # opened_state present
     ids = build_expected_unique_ids("d", {
-        "covers": [{"opening_state_address": "DB1,X0.2", "open_command_address": "DB1,X0.0"}],
+        "covers": [{
+            "opening_state_address": "DB1,X0.2",
+            "open_command_address": "DB1,X0.0",
+            "close_command_address": "DB1,X0.1",
+            "uid": "uid-opened",
+        }],
     })
-    assert "d:cover:opened:DB1,X0.2" in ids
+    assert "d:uid-opened" in ids
 
     # closing_state when no opening_state
     ids = build_expected_unique_ids("d", {
-        "covers": [{"closing_state_address": "DB1,X0.3", "open_command_address": "DB1,X0.0"}],
+        "covers": [{
+            "closing_state_address": "DB1,X0.3",
+            "open_command_address": "DB1,X0.0",
+            "close_command_address": "DB1,X0.1",
+            "uid": "uid-closed",
+        }],
     })
-    assert "d:cover:closed:DB1,X0.3" in ids
+    assert "d:uid-closed" in ids
 
-    # open_command as fallback
+    # only open/close command, no end-stop sensors
     ids = build_expected_unique_ids("d", {
-        "covers": [{"open_command_address": "DB1,X0.0"}],
+        "covers": [{
+            "open_command_address": "DB1,X0.0",
+            "close_command_address": "DB1,X0.1",
+            "uid": "uid-command",
+        }],
     })
-    assert "d:cover:command:DB1,X0.0" in ids
+    assert "d:uid-command" in ids
+
+    # missing close_command_address: no entity would actually be created
+    ids = build_expected_unique_ids("d", {
+        "covers": [{"open_command_address": "DB1,X0.0", "uid": "uid-incomplete"}],
+    })
+    assert "d:uid-incomplete" not in ids
 
 
 def test_build_expected_unique_ids_skips_items_without_address():
@@ -198,15 +239,92 @@ def test_build_expected_unique_ids_skips_items_without_address():
 def test_build_entity_area_map():
     """Area map returns correct unique_id → area_id mapping."""
     options = {
-        "sensors": [{"address": "DB1,REAL0", "area": "kitchen"}],
-        "binary_sensors": [{"address": "DB1,X0.0"}],  # no area
-        "lights": [{"state_address": "DB1,X1.0", "area": "bedroom"}],
+        "sensors": [{"address": "DB1,REAL0", "area": "kitchen", "uid": "uid-s"}],
+        "binary_sensors": [{"address": "DB1,X0.0", "uid": "uid-bs"}],  # no area
+        "lights": [
+            {"state_address": "DB1,X1.0", "area": "bedroom", "uid": "uid-l"}
+        ],
     }
     area_map = build_entity_area_map("dev", options)
 
-    assert area_map["dev:sensor:DB1,REAL0"] == "kitchen"
-    assert area_map["dev:binary_sensor:DB1,X0.0"] is None
-    assert area_map["dev:light:DB1,X1.0"] == "bedroom"
+    assert area_map["dev:uid-s"] == "kitchen"
+    assert area_map["dev:uid-bs"] is None
+    assert area_map["dev:uid-l"] == "bedroom"
+
+
+# ---------------------------------------------------------------------------
+# generate_uid / ensure_item_uids
+# ---------------------------------------------------------------------------
+
+
+def test_generate_uid_format_and_uniqueness():
+    """generate_uid returns short, unique hex strings."""
+    uid1 = generate_uid()
+    uid2 = generate_uid()
+    assert uid1 != uid2
+    assert len(uid1) == 12
+    int(uid1, 16)  # must be valid hex
+
+
+def test_ensure_item_uids_freezes_legacy_id_for_existing_entity():
+    """An item with no uid but a legacy address gets that exact id frozen."""
+    options = {
+        "sensors": [{"address": "DB1,REAL0"}],
+    }
+    changed = ensure_item_uids("dev", options)
+    assert changed is True
+    # The legacy unique_id was "dev:sensor:DB1,REAL0" -> uid is the suffix.
+    assert options["sensors"][0]["uid"] == "sensor:DB1,REAL0"
+
+
+def test_ensure_item_uids_assigns_fresh_uid_when_no_legacy_match():
+    """An item that never produced a real entity gets a random uid instead."""
+    options = {
+        "sensors": [{"name": "no address, never had an entity"}],
+    }
+    changed = ensure_item_uids("dev", options)
+    assert changed is True
+    uid = options["sensors"][0]["uid"]
+    assert uid
+    assert uid != "sensor:"
+
+
+def test_ensure_item_uids_noop_when_uid_already_present():
+    """Items that already have a uid are left untouched."""
+    options = {
+        "sensors": [{"address": "DB1,REAL0", "uid": "existing-uid"}],
+    }
+    changed = ensure_item_uids("dev", options)
+    assert changed is False
+    assert options["sensors"][0]["uid"] == "existing-uid"
+
+
+def test_ensure_item_uids_idempotent():
+    """Calling ensure_item_uids twice doesn't change anything the second time."""
+    options = {
+        "sensors": [{"address": "DB1,REAL0"}],
+        "switches": [{"state_address": "DB1,X0.0"}],
+    }
+    assert ensure_item_uids("dev", options) is True
+    first_uids = {
+        key: [dict(i) for i in items] for key, items in options.items()
+    }
+    assert ensure_item_uids("dev", options) is False
+    assert options == first_uids
+
+
+def test_ensure_item_uids_editing_address_does_not_change_uid():
+    """Regression test: editing an item's address must not change its uid."""
+    options = {"sensors": [{"address": "DB1,REAL0"}]}
+    ensure_item_uids("dev", options)
+    uid = options["sensors"][0]["uid"]
+
+    # Simulate the user editing the address via the options flow.
+    options["sensors"][0]["address"] = "DB1,REAL99"
+    changed = ensure_item_uids("dev", options)
+
+    assert changed is False
+    assert options["sensors"][0]["uid"] == uid
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -258,11 +258,11 @@ def test_build_entity_area_map():
 
 
 def test_generate_uid_format_and_uniqueness():
-    """generate_uid returns short, unique hex strings."""
+    """generate_uid returns unique hex strings from a full UUID4."""
     uid1 = generate_uid()
     uid2 = generate_uid()
     assert uid1 != uid2
-    assert len(uid1) == 12
+    assert len(uid1) == 32
     int(uid1, 16)  # must be valid hex
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -148,19 +148,19 @@ def test_build_expected_unique_ids_all_entity_types():
 
     ids = build_expected_unique_ids("dev", options)
 
-    assert "dev:uid-sensor" in ids
-    assert "dev:uid-binary" in ids
-    assert "dev:uid-switch" in ids
-    assert "dev:uid-cover-pos" in ids
-    assert "dev:uid-cover-trad" in ids
-    assert "dev:uid-button" in ids
-    assert "dev:uid-light-1" in ids
-    assert "dev:uid-light-2" in ids
-    assert "dev:uid-number" in ids
-    assert "dev:uid-text" in ids
-    assert "dev:uid-climate-direct" in ids
-    assert "dev:uid-climate-setpoint" in ids
-    assert "dev:uid-entity-sync" in ids
+    assert "uid-sensor" in ids
+    assert "uid-binary" in ids
+    assert "uid-switch" in ids
+    assert "uid-cover-pos" in ids
+    assert "uid-cover-trad" in ids
+    assert "uid-button" in ids
+    assert "uid-light-1" in ids
+    assert "uid-light-2" in ids
+    assert "uid-number" in ids
+    assert "uid-text" in ids
+    assert "uid-climate-direct" in ids
+    assert "uid-climate-setpoint" in ids
+    assert "uid-entity-sync" in ids
     assert "dev:connection" in ids
 
 
@@ -194,7 +194,7 @@ def test_build_expected_unique_ids_traditional_cover_variants():
             "uid": "uid-opened",
         }],
     })
-    assert "d:uid-opened" in ids
+    assert "uid-opened" in ids
 
     # closing_state when no opening_state
     ids = build_expected_unique_ids("d", {
@@ -205,7 +205,7 @@ def test_build_expected_unique_ids_traditional_cover_variants():
             "uid": "uid-closed",
         }],
     })
-    assert "d:uid-closed" in ids
+    assert "uid-closed" in ids
 
     # only open/close command, no end-stop sensors
     ids = build_expected_unique_ids("d", {
@@ -215,13 +215,13 @@ def test_build_expected_unique_ids_traditional_cover_variants():
             "uid": "uid-command",
         }],
     })
-    assert "d:uid-command" in ids
+    assert "uid-command" in ids
 
     # missing close_command_address: no entity would actually be created
     ids = build_expected_unique_ids("d", {
         "covers": [{"open_command_address": "DB1,X0.0", "uid": "uid-incomplete"}],
     })
-    assert "d:uid-incomplete" not in ids
+    assert "uid-incomplete" not in ids
 
 
 def test_build_expected_unique_ids_skips_items_without_address():
@@ -247,9 +247,9 @@ def test_build_entity_area_map():
     }
     area_map = build_entity_area_map("dev", options)
 
-    assert area_map["dev:uid-s"] == "kitchen"
-    assert area_map["dev:uid-bs"] is None
-    assert area_map["dev:uid-l"] == "bedroom"
+    assert area_map["uid-s"] == "kitchen"
+    assert area_map["uid-bs"] is None
+    assert area_map["uid-l"] == "bedroom"
 
 
 # ---------------------------------------------------------------------------
@@ -273,8 +273,8 @@ def test_ensure_item_uids_freezes_legacy_id_for_existing_entity():
     }
     changed = ensure_item_uids("dev", options)
     assert changed is True
-    # The legacy unique_id was "dev:sensor:DB1,REAL0" -> uid is the suffix.
-    assert options["sensors"][0]["uid"] == "sensor:DB1,REAL0"
+    # uid now stores the complete legacy unique_id verbatim, device_id included.
+    assert options["sensors"][0]["uid"] == "dev:sensor:DB1,REAL0"
 
 
 def test_ensure_item_uids_assigns_fresh_uid_when_no_legacy_match():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -125,6 +125,7 @@ def test_update_listener_applies_area_to_new_entity_after_reload(monkeypatch):
                 {
                     const.CONF_ADDRESS: "DB1,REAL0",
                     const.CONF_AREA: "kitchen",
+                    const.CONF_UID: "sensor-uid-1",
                 }
             ]
         },
@@ -147,7 +148,7 @@ def test_update_listener_applies_area_to_new_entity_after_reload(monkeypatch):
             if (
                 self.entity_available
                 and domain == const.DOMAIN
-                and unique_id == "test-device:sensor:DB1,REAL0"
+                and unique_id == "sensor-uid-1"
             ):
                 return "sensor.imported_sensor"
             return None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -156,3 +156,87 @@ def test_write_multi_service_registration(monkeypatch):
     assert "health_check" in registered_services, f"health_check not in {registered_services}"
     assert "write_multi" in registered_services, f"write_multi not in {registered_services}"
 
+
+def test_migrate_backfills_uid_for_legacy_items(monkeypatch):
+    """Legacy items with no 'uid' get one assigned, matching their current
+    (address-based) unique_id, so the entity's identity doesn't change."""
+    hass = HomeAssistant()
+
+    hass.services = type(
+        "obj", (object,), {"async_register": lambda *a, **k: None}
+    )()
+
+    entry = DummyConfigEntry(
+        data={
+            s7init.CONF_HOST: "plc.local",
+            s7init.CONF_RACK: 0,
+            s7init.CONF_SLOT: 1,
+        },
+        options={
+            "sensors": [{"address": "DB1,REAL0", "name": "Legacy Sensor"}],
+        },
+        entry_id="test_uid_backfill",
+    )
+
+    update_calls = []
+
+    def fake_update_entry(entry, **kwargs):
+        update_calls.append((entry.entry_id, kwargs))
+
+    hass.config_entries.async_update_entry = fake_update_entry
+    hass.config_entries.async_forward_entry_setups = lambda e, p: asyncio.sleep(0)
+
+    monkeypatch.setattr(
+        s7init, "S7Coordinator", lambda *a, **k: DummyCoordinator(*a, **k)
+    )
+
+    asyncio.run(s7init.async_setup_entry(hass, entry))
+
+    # A uid was assigned and persisted.
+    assert len(update_calls) == 1
+    new_options = update_calls[0][1]["options"]
+    sensor_item = new_options["sensors"][0]
+    assert sensor_item["uid"] == "sensor:DB1,REAL0"
+    # The item's own address/name are untouched.
+    assert sensor_item["address"] == "DB1,REAL0"
+    assert sensor_item["name"] == "Legacy Sensor"
+
+
+def test_migrate_uid_backfill_is_a_noop_once_uid_present(monkeypatch):
+    """No further migration once every item already has a uid."""
+    hass = HomeAssistant()
+
+    hass.services = type(
+        "obj", (object,), {"async_register": lambda *a, **k: None}
+    )()
+
+    entry = DummyConfigEntry(
+        data={
+            s7init.CONF_HOST: "plc.local",
+            s7init.CONF_RACK: 0,
+            s7init.CONF_SLOT: 1,
+        },
+        options={
+            "sensors": [
+                {"address": "DB1,REAL0", "name": "Sensor", "uid": "already-set"}
+            ],
+        },
+        entry_id="test_uid_noop",
+    )
+
+    update_calls = []
+
+    def fake_update_entry(entry, **kwargs):
+        update_calls.append((entry.entry_id, kwargs))
+
+    hass.config_entries.async_update_entry = fake_update_entry
+    hass.config_entries.async_forward_entry_setups = lambda e, p: asyncio.sleep(0)
+
+    monkeypatch.setattr(
+        s7init, "S7Coordinator", lambda *a, **k: DummyCoordinator(*a, **k)
+    )
+
+    asyncio.run(s7init.async_setup_entry(hass, entry))
+
+    assert len(update_calls) == 0
+    assert entry.options["sensors"][0]["uid"] == "already-set"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -115,6 +115,72 @@ def test_update_listener_triggers_reload():
     assert reload_called == [entry.entry_id]
 
 
+def test_update_listener_applies_area_to_new_entity_after_reload(monkeypatch):
+    """Test that areas are applied after newly imported entities are created."""
+    hass = HomeAssistant()
+
+    entry = DummyConfigEntry(
+        options={
+            const.CONF_SENSORS: [
+                {
+                    const.CONF_ADDRESS: "DB1,REAL0",
+                    const.CONF_AREA: "kitchen",
+                }
+            ]
+        },
+        entry_id="entry1",
+    )
+
+    entry.runtime_data = s7init.RuntimeEntryData(
+        coordinator=None,
+        name="Test PLC",
+        host="plc.local",
+        device_id="test-device",
+    )
+
+    class FakeEntityRegistry:
+        def __init__(self):
+            self.entity_available = False
+            self.updated = []
+
+        def async_get_entity_id(self, platform, domain, unique_id):
+            if (
+                self.entity_available
+                and domain == const.DOMAIN
+                and unique_id == "test-device:sensor:DB1,REAL0"
+            ):
+                return "sensor.imported_sensor"
+            return None
+
+        def async_update_entity(self, entity_id, **kwargs):
+            self.updated.append((entity_id, kwargs))
+
+    entity_registry = FakeEntityRegistry()
+
+    monkeypatch.setattr(
+        s7init.er,
+        "async_get",
+        lambda hass: entity_registry,
+    )
+
+    async def fake_reload(entry_id):
+        assert entry_id == "entry1"
+
+        # Simulate the entity being created during integration reload.
+        entity_registry.entity_available = True
+
+    hass.config_entries.async_reload = fake_reload
+
+    asyncio.run(s7init._async_update_listener(hass, entry))
+
+    assert entity_registry.updated == [
+        (
+            "sensor.imported_sensor",
+            {"area_id": "kitchen"},
+        )
+    ]
+
+
 def test_write_multi_service_registration(monkeypatch):
     """Test that write_multi service is registered."""
     hass = HomeAssistant()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -196,7 +196,7 @@ def test_migrate_backfills_uid_for_legacy_items(monkeypatch):
     assert len(update_calls) == 1
     new_options = update_calls[0][1]["options"]
     sensor_item = new_options["sensors"][0]
-    assert sensor_item["uid"] == "sensor:DB1,REAL0"
+    assert sensor_item["uid"] == "s7plc-plc.local-0-1:sensor:DB1,REAL0"
     # The item's own address/name are untouched.
     assert sensor_item["address"] == "DB1,REAL0"
     assert sensor_item["name"] == "Legacy Sensor"

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -20,6 +20,7 @@ from custom_components.s7plc.const import (
     CONF_SCAN_INTERVAL,
     CONF_STATE_ADDRESS,
     CONF_SYNC_STATE,
+    CONF_UID,
 )
 
 # Test constants
@@ -230,11 +231,13 @@ async def test_async_setup_entry_with_lights(fake_hass, mock_coordinator, device
             {
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Light 1",
+                CONF_UID: "uid-1",
             },
             {
                 CONF_STATE_ADDRESS: "db1,x0.1",
                 CONF_NAME: "Light 2",
                 CONF_COMMAND_ADDRESS: "db1,x0.2",
+                CONF_UID: "uid-2",
             }
         ]
     }
@@ -266,7 +269,11 @@ async def test_async_setup_entry_skip_missing_state_address(fake_hass, mock_coor
     config_entry.options = {
         CONF_LIGHTS: [
             {CONF_NAME: "No Address Light"},
-            {CONF_STATE_ADDRESS: "db1,x0.0", CONF_NAME: "Valid Light"},
+            {
+                CONF_STATE_ADDRESS: "db1,x0.0",
+                CONF_NAME: "Valid Light",
+                CONF_UID: "uid-1",
+            },
         ]
     }
     
@@ -292,7 +299,7 @@ async def test_async_setup_entry_default_name(fake_hass, mock_coordinator, devic
     config_entry = MagicMock()
     config_entry.options = {
         CONF_LIGHTS: [
-            {CONF_STATE_ADDRESS: "db1,x0.0"}  # No name
+            {CONF_STATE_ADDRESS: "db1,x0.0", CONF_UID: "uid-1"}  # No name
         ]
     }
     
@@ -318,6 +325,7 @@ async def test_async_setup_entry_default_command_address(fake_hass, mock_coordin
             {
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Light 1",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -346,6 +354,7 @@ async def test_async_setup_entry_with_scan_interval(fake_hass, mock_coordinator,
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Light 1",
                 CONF_SCAN_INTERVAL: 5,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -374,6 +383,7 @@ async def test_async_setup_entry_with_sync_state(fake_hass, mock_coordinator, de
                 CONF_COMMAND_ADDRESS: "db1,x0.1",
                 CONF_NAME: "Light 1",
                 CONF_SYNC_STATE: True,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -400,6 +410,7 @@ async def test_async_setup_entry_sync_state_default_false(fake_hass, mock_coordi
             {
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Light 1",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -727,6 +738,7 @@ async def test_async_setup_entry_dimmer_lights(fake_hass, mock_coordinator, devi
                 CONF_BRIGHTNESS_STATE_ADDRESS: "db1,b0",
                 CONF_BRIGHTNESS_COMMAND_ADDRESS: "db1,b1",
                 CONF_BRIGHTNESS_SCALE: 255,
+                CONF_UID: "uid-1",
             },
             {
                 CONF_STATE_ADDRESS: "db1,x0.2",
@@ -735,6 +747,7 @@ async def test_async_setup_entry_dimmer_lights(fake_hass, mock_coordinator, devi
                 CONF_BRIGHTNESS_STATE_ADDRESS: "db1,b2",
                 CONF_BRIGHTNESS_COMMAND_ADDRESS: "db1,b3",
                 CONF_BRIGHTNESS_SCALE: 100,
+                CONF_UID: "uid-2",
             },
         ]
     }
@@ -783,6 +796,7 @@ async def test_async_setup_entry_dimmer_skip_missing_state_address(
                 CONF_BRIGHTNESS_STATE_ADDRESS: "db1,b0",
                 CONF_BRIGHTNESS_COMMAND_ADDRESS: "db1,b1",
                 CONF_BRIGHTNESS_SCALE: 255,
+                CONF_UID: "uid-1",
             },
         ]
     }
@@ -810,6 +824,7 @@ async def test_async_setup_entry_mixed_lights_and_dimmers(
             {
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Regular Light",
+                CONF_UID: "uid-1",
             },
             {
                 CONF_STATE_ADDRESS: "db1,x0.2",
@@ -818,6 +833,7 @@ async def test_async_setup_entry_mixed_lights_and_dimmers(
                 CONF_BRIGHTNESS_STATE_ADDRESS: "db1,b0",
                 CONF_BRIGHTNESS_COMMAND_ADDRESS: "db1,b1",
                 CONF_BRIGHTNESS_SCALE: 255,
+                CONF_UID: "uid-2",
             },
         ],
     }
@@ -848,6 +864,7 @@ async def test_async_setup_entry_dimmer_default_command_address(
                 CONF_NAME: "Dimmer",
                 CONF_BRIGHTNESS_STATE_ADDRESS: "db1,b0",
                 CONF_BRIGHTNESS_SCALE: 255,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -957,6 +974,7 @@ async def test_async_setup_entry_with_pulse(fake_hass, mock_coordinator, device_
                 CONF_NAME: "Pulse Light",
                 CONF_PULSE_COMMAND: True,
                 CONF_PULSE_DURATION: 1.5,
+                CONF_UID: "uid-1",
             }
         ]
     }

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -83,7 +83,11 @@ def test_entry_payload_maps_entity_ids(monkeypatch) -> None:
         data={"host": "192.0.2.1"},
         options={
             "sensors": [
-                {"name": "Temp", "address": "DB1,REAL0"},
+                {
+                    "name": "Temp",
+                    "address": "DB1,REAL0",
+                    "uid": "dev1:sensor:DB1,REAL0",
+                },
                 {"name": "Broken"},
             ]
         },

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -39,10 +39,10 @@ def entry_with_orphans(monkeypatch):
         },
         options={
             "sensors": [
-                {"address": "DB1,REAL0", "name": "Active Sensor"}
+                {"address": "DB1,REAL0", "name": "Active Sensor", "uid": "s1"}
             ],
             "switches": [
-                {"state_address": "DB1,X0.0", "name": "Active Switch"}
+                {"state_address": "DB1,X0.0", "name": "Active Switch", "uid": "sw1"}
             ],
         },
         entry_id="test_entry",
@@ -65,12 +65,12 @@ def entry_with_orphans(monkeypatch):
     # Add active entities (should NOT be removed)
     entity_reg.entities["sensor.active_sensor"] = MockEntityRegistryEntry(
         entity_id="sensor.active_sensor",
-        unique_id="test_device:sensor:DB1,REAL0",
+        unique_id="test_device:s1",
         config_entry_id="test_entry",
     )
     entity_reg.entities["switch.active_switch"] = MockEntityRegistryEntry(
         entity_id="switch.active_switch",
-        unique_id="test_device:switch:DB1,X0.0",
+        unique_id="test_device:sw1",
         config_entry_id="test_entry",
     )
     entity_reg.entities["binary_sensor.connection"] = MockEntityRegistryEntry(
@@ -78,16 +78,16 @@ def entry_with_orphans(monkeypatch):
         unique_id="test_device:connection",
         config_entry_id="test_entry",
     )
-    
-    # Add orphaned entities (should be removed)
+
+    # Add orphaned entities (should be removed) - uids not present in options
     entity_reg.entities["sensor.old_sensor"] = MockEntityRegistryEntry(
         entity_id="sensor.old_sensor",
-        unique_id="test_device:sensor:DB1,REAL100",
+        unique_id="test_device:old-sensor-uid",
         config_entry_id="test_entry",
     )
     entity_reg.entities["switch.old_switch"] = MockEntityRegistryEntry(
         entity_id="switch.old_switch",
-        unique_id="test_device:switch:DB1,X10.0",
+        unique_id="test_device:old-switch-uid",
         config_entry_id="test_entry",
     )
     
@@ -174,39 +174,46 @@ def test_get_expected_unique_ids_all_entity_types(entry_with_orphans):
     
     # Add all entity types to config
     entry.options = {
-        "sensors": [{"address": "DB1,REAL0"}],
-        "binary_sensors": [{"address": "DB1,X0.0"}],
-        "switches": [{"state_address": "DB1,X0.1"}],
+        "sensors": [{"address": "DB1,REAL0", "uid": "uid-sensor"}],
+        "binary_sensors": [{"address": "DB1,X0.0", "uid": "uid-binary"}],
+        "switches": [{"state_address": "DB1,X0.1", "uid": "uid-switch"}],
         "covers": [
-            {"position_state_address": "DB1,INT0"},  # Position cover
-            {"open_command_address": "DB1,X1.0", "close_command_address": "DB1,X1.1", "opening_state_address": "DB1,X1.2"},  # Traditional cover
+            {"position_state_address": "DB1,INT0", "uid": "uid-cover-pos"},  # Position cover
+            {
+                "open_command_address": "DB1,X1.0",
+                "close_command_address": "DB1,X1.1",
+                "opening_state_address": "DB1,X1.2",
+                "uid": "uid-cover-trad",
+            },  # Traditional cover
         ],
-        "buttons": [{"address": "DB1,X2.0"}],
+        "buttons": [{"address": "DB1,X2.0", "uid": "uid-button"}],
         "lights": [
-            {"state_address": "DB1,X2.1"},
-            {"state_address": "DB1,B10", "brightness_scale": 255},
+            {"state_address": "DB1,X2.1", "uid": "uid-light-1"},
+            {"state_address": "DB1,B10", "brightness_scale": 255, "uid": "uid-light-2"},
         ],
-        "numbers": [{"address": "DB1,INT10"}],
-        "texts": [{"address": "DB1,STRING0"}],
-        "entity_sync": [{"address": "DB1,REAL100", "source_entity": "sensor.test"}],
+        "numbers": [{"address": "DB1,INT10", "uid": "uid-number"}],
+        "texts": [{"address": "DB1,STRING0", "uid": "uid-text"}],
+        "entity_sync": [
+            {"address": "DB1,REAL100", "source_entity": "sensor.test", "uid": "uid-sync"}
+        ],
     }
-    
+
     flow = repairs.OrphanedEntitiesRepairFlow(entry.entry_id)
     flow.hass = hass
-    
+
     expected = asyncio.run(flow._get_expected_unique_ids(entry))
-    
-    assert "test_device:sensor:DB1,REAL0" in expected
-    assert "test_device:binary_sensor:DB1,X0.0" in expected
-    assert "test_device:switch:DB1,X0.1" in expected
-    assert "test_device:cover:position:DB1,INT0" in expected
-    assert "test_device:cover:opened:DB1,X1.2" in expected
-    assert "test_device:button:DB1,X2.0" in expected
-    assert "test_device:light:DB1,X2.1" in expected
-    assert "test_device:light:DB1,B10" in expected
-    assert "test_device:number:DB1,INT10" in expected
-    assert "test_device:text:DB1,STRING0" in expected
-    assert "test_device:entity_sync:DB1,REAL100" in expected
+
+    assert "test_device:uid-sensor" in expected
+    assert "test_device:uid-binary" in expected
+    assert "test_device:uid-switch" in expected
+    assert "test_device:uid-cover-pos" in expected
+    assert "test_device:uid-cover-trad" in expected
+    assert "test_device:uid-button" in expected
+    assert "test_device:uid-light-1" in expected
+    assert "test_device:uid-light-2" in expected
+    assert "test_device:uid-number" in expected
+    assert "test_device:uid-text" in expected
+    assert "test_device:uid-sync" in expected
     assert "test_device:connection" in expected
 
 
@@ -224,6 +231,7 @@ def test_get_expected_unique_ids_traditional_cover_variants():
                     "open_command_address": "DB1,X0.0",
                     "close_command_address": "DB1,X0.1",
                     "opening_state_address": "DB1,X0.2",
+                    "uid": "uid-opened",
                 }
             ]
         },
@@ -234,12 +242,12 @@ def test_get_expected_unique_ids_traditional_cover_variants():
     )
     hass.data[DOMAIN] = {}
     hass.config_entries._entries.append(entry)
-    
+
     flow = repairs.OrphanedEntitiesRepairFlow("test1")
     flow.hass = hass
     expected = asyncio.run(flow._get_expected_unique_ids(entry))
-    assert "dev1:cover:opened:DB1,X0.2" in expected
-    
+    assert "dev1:uid-opened" in expected
+
     # Test with closed_state only
     entry2 = ConfigEntry(
         options={
@@ -248,6 +256,7 @@ def test_get_expected_unique_ids_traditional_cover_variants():
                     "open_command_address": "DB1,X0.0",
                     "close_command_address": "DB1,X0.1",
                     "closing_state_address": "DB1,X0.3",
+                    "uid": "uid-closed",
                 }
             ]
         },
@@ -257,12 +266,12 @@ def test_get_expected_unique_ids_traditional_cover_variants():
         coordinator=None, name="PLC2", host="192.168.1.2", device_id="dev2"
     )
     hass.config_entries._entries.append(entry2)
-    
+
     flow2 = repairs.OrphanedEntitiesRepairFlow("test2")
     flow2.hass = hass
     expected2 = asyncio.run(flow2._get_expected_unique_ids(entry2))
-    assert "dev2:cover:closed:DB1,X0.3" in expected2
-    
+    assert "dev2:uid-closed" in expected2
+
     # Test with command only (no state addresses)
     entry3 = ConfigEntry(
         options={
@@ -270,6 +279,7 @@ def test_get_expected_unique_ids_traditional_cover_variants():
                 {
                     "open_command_address": "DB1,X0.0",
                     "close_command_address": "DB1,X0.1",
+                    "uid": "uid-command",
                 }
             ]
         },
@@ -279,11 +289,11 @@ def test_get_expected_unique_ids_traditional_cover_variants():
         coordinator=None, name="PLC3", host="192.168.1.3", device_id="dev3"
     )
     hass.config_entries._entries.append(entry3)
-    
+
     flow3 = repairs.OrphanedEntitiesRepairFlow("test3")
     flow3.hass = hass
     expected3 = asyncio.run(flow3._get_expected_unique_ids(entry3))
-    assert "dev3:cover:command:DB1,X0.0" in expected3
+    assert "dev3:uid-command" in expected3
 
 
 def test_async_create_fix_flow_extracts_entry_id():

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -65,12 +65,12 @@ def entry_with_orphans(monkeypatch):
     # Add active entities (should NOT be removed)
     entity_reg.entities["sensor.active_sensor"] = MockEntityRegistryEntry(
         entity_id="sensor.active_sensor",
-        unique_id="test_device:s1",
+        unique_id="s1",
         config_entry_id="test_entry",
     )
     entity_reg.entities["switch.active_switch"] = MockEntityRegistryEntry(
         entity_id="switch.active_switch",
-        unique_id="test_device:sw1",
+        unique_id="sw1",
         config_entry_id="test_entry",
     )
     entity_reg.entities["binary_sensor.connection"] = MockEntityRegistryEntry(
@@ -203,17 +203,17 @@ def test_get_expected_unique_ids_all_entity_types(entry_with_orphans):
 
     expected = asyncio.run(flow._get_expected_unique_ids(entry))
 
-    assert "test_device:uid-sensor" in expected
-    assert "test_device:uid-binary" in expected
-    assert "test_device:uid-switch" in expected
-    assert "test_device:uid-cover-pos" in expected
-    assert "test_device:uid-cover-trad" in expected
-    assert "test_device:uid-button" in expected
-    assert "test_device:uid-light-1" in expected
-    assert "test_device:uid-light-2" in expected
-    assert "test_device:uid-number" in expected
-    assert "test_device:uid-text" in expected
-    assert "test_device:uid-sync" in expected
+    assert "uid-sensor" in expected
+    assert "uid-binary" in expected
+    assert "uid-switch" in expected
+    assert "uid-cover-pos" in expected
+    assert "uid-cover-trad" in expected
+    assert "uid-button" in expected
+    assert "uid-light-1" in expected
+    assert "uid-light-2" in expected
+    assert "uid-number" in expected
+    assert "uid-text" in expected
+    assert "uid-sync" in expected
     assert "test_device:connection" in expected
 
 
@@ -246,7 +246,7 @@ def test_get_expected_unique_ids_traditional_cover_variants():
     flow = repairs.OrphanedEntitiesRepairFlow("test1")
     flow.hass = hass
     expected = asyncio.run(flow._get_expected_unique_ids(entry))
-    assert "dev1:uid-opened" in expected
+    assert "uid-opened" in expected
 
     # Test with closed_state only
     entry2 = ConfigEntry(
@@ -270,7 +270,7 @@ def test_get_expected_unique_ids_traditional_cover_variants():
     flow2 = repairs.OrphanedEntitiesRepairFlow("test2")
     flow2.hass = hass
     expected2 = asyncio.run(flow2._get_expected_unique_ids(entry2))
-    assert "dev2:uid-closed" in expected2
+    assert "uid-closed" in expected2
 
     # Test with command only (no state addresses)
     entry3 = ConfigEntry(
@@ -293,7 +293,7 @@ def test_get_expected_unique_ids_traditional_cover_variants():
     flow3 = repairs.OrphanedEntitiesRepairFlow("test3")
     flow3.hass = hass
     expected3 = asyncio.run(flow3._get_expected_unique_ids(entry3))
-    assert "dev3:uid-command" in expected3
+    assert "uid-command" in expected3
 
 
 def test_async_create_fix_flow_extracts_entry_id():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -350,6 +350,7 @@ async def test_async_setup_entry_with_sensors():
                 "value_multiplier": None,
                 "real_precision": None,
                 "scan_interval": None,
+                "uid": "test-uid",
             }
         ]
     }
@@ -428,11 +429,12 @@ async def test_async_setup_entry_with_entity_syncs():
                 "address": "DB1,REAL0",
                 "source_entity": "sensor.test",
                 "name": "Test Sync",
+                "uid": "test-uid",
             }
         ]
     }
     async_add_entities = MagicMock()
-    
+
     with patch(
         "custom_components.s7plc.sensor.get_coordinator_and_device_info"
     ) as mock_get_coord:
@@ -444,9 +446,9 @@ async def test_async_setup_entry_with_entity_syncs():
             {"name": "Test Device"},
             "test-device",
         )
-        
+
         await async_setup_entry(hass, entry, async_add_entities)
-        
+
         # async_add_entities called twice: first for sensors+metrics, then for syncs
         assert async_add_entities.call_count == 2
         # First call: 14 metrics sensors
@@ -508,12 +510,13 @@ async def test_async_setup_entry_default_names():
         "sensors": [
             {
                 "address": "DB1,REAL0",
+                "uid": "test-uid",
                 # No name provided
             }
         ]
     }
     async_add_entities = MagicMock()
-    
+
     with patch(
         "custom_components.s7plc.sensor.get_coordinator_and_device_info"
     ) as mock_get_coord:
@@ -526,9 +529,9 @@ async def test_async_setup_entry_default_names():
             {"name": "Test Device"},
             "test-device",
         )
-        
+
         await async_setup_entry(hass, entry, async_add_entities)
-        
+
         # Should create 1 user sensor + 14 metrics sensors
         assert async_add_entities.called
         entities = async_add_entities.call_args[0][0]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -16,6 +16,7 @@ from custom_components.s7plc.const import (
     CONF_STATE_ADDRESS,
     CONF_SWITCHES,
     CONF_SYNC_STATE,
+    CONF_UID,
 )
 
 # Test constants
@@ -217,11 +218,13 @@ async def test_async_setup_entry_with_switches(fake_hass, mock_coordinator, devi
             {
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Switch 1",
+                CONF_UID: "uid-1",
             },
             {
                 CONF_STATE_ADDRESS: "db1,x0.1",
                 CONF_NAME: "Switch 2",
                 CONF_COMMAND_ADDRESS: "db1,x0.2",
+                CONF_UID: "uid-2",
             }
         ]
     }
@@ -253,7 +256,11 @@ async def test_async_setup_entry_skip_missing_state_address(fake_hass, mock_coor
     config_entry.options = {
         CONF_SWITCHES: [
             {CONF_NAME: "No Address Switch"},
-            {CONF_STATE_ADDRESS: "db1,x0.0", CONF_NAME: "Valid Switch"},
+            {
+                CONF_STATE_ADDRESS: "db1,x0.0",
+                CONF_NAME: "Valid Switch",
+                CONF_UID: "uid-1",
+            },
         ]
     }
     
@@ -279,7 +286,7 @@ async def test_async_setup_entry_default_name(fake_hass, mock_coordinator, devic
     config_entry = MagicMock()
     config_entry.options = {
         CONF_SWITCHES: [
-            {CONF_STATE_ADDRESS: "db1,x0.0"}  # No name
+            {CONF_STATE_ADDRESS: "db1,x0.0", CONF_UID: "uid-1"}  # No name
         ]
     }
     
@@ -305,6 +312,7 @@ async def test_async_setup_entry_default_command_address(fake_hass, mock_coordin
             {
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Switch 1",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -333,6 +341,7 @@ async def test_async_setup_entry_with_scan_interval(fake_hass, mock_coordinator,
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Switch 1",
                 CONF_SCAN_INTERVAL: 5,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -361,6 +370,7 @@ async def test_async_setup_entry_with_sync_state(fake_hass, mock_coordinator, de
                 CONF_COMMAND_ADDRESS: "db1,x0.1",
                 CONF_NAME: "Switch 1",
                 CONF_SYNC_STATE: True,
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -387,6 +397,7 @@ async def test_async_setup_entry_sync_state_default_false(fake_hass, mock_coordi
             {
                 CONF_STATE_ADDRESS: "db1,x0.0",
                 CONF_NAME: "Switch 1",
+                CONF_UID: "uid-1",
             }
         ]
     }
@@ -496,6 +507,7 @@ async def test_async_setup_entry_with_pulse(fake_hass, mock_coordinator, device_
                 CONF_NAME: "Pulse Switch",
                 CONF_PULSE_COMMAND: True,
                 CONF_PULSE_DURATION: 1.5,
+                CONF_UID: "uid-1",
             }
         ]
     }


### PR DESCRIPTION
## Summary

`test_update_listener_applies_area_to_new_entity_after_reload` (added in `6f6331e`, merged alongside #92) is failing on `main` as of the current tip — reproducible directly on plain `main`, unrelated to any other work.

The test's fixture sensor item never set `CONF_UID`. Since #92, `_iter_entity_unique_ids()` (which `build_entity_area_map()` relies on) requires a `uid` on each item and **silently skips** any item missing one — no longer deriving identity from `device_id`. Without a `uid`, `build_entity_area_map()` returned an empty mapping, so the area-update loop never ran, and `async_get_entity_id`'s mock check against the old `"{device_id}:sensor:{address}"` format never had a chance to match anyway.

Fix: give the fixture item a `CONF_UID` and match the mock's `async_get_entity_id` against that uid instead of the retired device-id-prefixed format.

## Test plan

- [x] `python3 -m py_compile` passes
- [x] Full `pytest` suite passes (547 passed) — was 1 failing before this fix, reproducible on plain `main`